### PR TITLE
Maintenance

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ project.ext {
     // internal build versions
     httpClientVersion = '4.5.13'
     azureKeyVaultClientVersion = '4.3.4'
-    abortMissionVersion = '2.8.0'
+    abortMissionVersion = '2.8.1'
     cucumberVersion = '7.1.0'
     jupiterVersion = '5.8.2'
     mockitoCoreVersion = '3.9.0'

--- a/lowkey-vault-app/build.gradle
+++ b/lowkey-vault-app/build.gradle
@@ -4,7 +4,7 @@ plugins {
     //noinspection SpellCheckingInspection
     id "io.freefair.lombok" version '6.2.0'
     id 'org.sonatype.gradle.plugins.scan' version '2.2.0'
-    id 'com.github.nagyesta.abort-mission-gradle-plugin' version '2.0.2'
+    id 'com.github.nagyesta.abort-mission-gradle-plugin' version '2.1.0'
 }
 
 group = "${rootProject.group}"

--- a/lowkey-vault-docker/build.gradle
+++ b/lowkey-vault-docker/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'com.github.nagyesta.abort-mission-gradle-plugin' version '2.0.2'
+    id 'com.github.nagyesta.abort-mission-gradle-plugin' version '2.1.0'
     id 'com.palantir.docker' version '0.30.0'
     id 'com.palantir.docker-run' version '0.30.0'
 }
@@ -96,7 +96,6 @@ test.finalizedBy tasks.dockerStop
 
 abortMission {
     toolVersion rootProject.ext.abortMissionVersion
-    relaxedValidation true
 }
 
 task publish {

--- a/lowkey-vault-docker/src/test/java/com/github/nagyesta/lowkeyvault/MissionOutlineDefinition.java
+++ b/lowkey-vault-docker/src/test/java/com/github/nagyesta/lowkeyvault/MissionOutlineDefinition.java
@@ -14,7 +14,8 @@ import java.util.Map;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
-import static com.github.nagyesta.abortmission.core.MissionControl.*;
+import static com.github.nagyesta.abortmission.core.MissionControl.matcher;
+import static com.github.nagyesta.abortmission.core.MissionControl.percentageBasedEvaluator;
 import static com.github.nagyesta.abortmission.core.outline.MissionOutline.SHARED_CONTEXT;
 
 public class MissionOutlineDefinition extends LaunchAbortHook {
@@ -54,7 +55,6 @@ public class MissionOutlineDefinition extends LaunchAbortHook {
                         .build();
                 ops.registerHealthCheck(tagPercentage);
             });
-            ops.registerHealthCheck(reportOnlyEvaluator(matcher().anyClass().build()).build());
         });
     }
 


### PR DESCRIPTION
- Updates Abort-Mission version (including Gradle plugin)
- Removes unnecessary relaxed schema config of Abort-Mission plugin
- Removes unused matcher from MissionOutlineDefinition

{patch}