### PR TITLE
Add request logging option

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,6 +22,8 @@ on:
       - 'LICENSE'
       - '.github/ISSUE_TEMPLATE/**'
       - '.github/assets/**'
+      - '.github/dependabot.yml'
+      - '.github/workflows/**'
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ main ]
@@ -32,6 +34,8 @@ on:
       - 'LICENSE'
       - '.github/ISSUE_TEMPLATE/**'
       - '.github/assets/**'
+      - '.github/dependabot.yml'
+      - '.github/workflows/**'
 
 permissions:
   # required for all workflows

--- a/.github/workflows/gradle-ci.yml
+++ b/.github/workflows/gradle-ci.yml
@@ -15,6 +15,8 @@ on:
       - 'LICENSE'
       - '.github/ISSUE_TEMPLATE/**'
       - '.github/assets/**'
+      - '.github/dependabot.yml'
+      - '.github/workflows/**'
 
 permissions: read-all
 
@@ -50,3 +52,16 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./lowkey-vault-app/build/reports/jacoco/report.xml
+          flags: app
+      - name: Upload coverage to Codecov - Client
+        uses: codecov/codecov-action@11d69070bf0bb19a473235e011c7890707db52de # v2.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./lowkey-vault-client/build/reports/jacoco/report.xml
+          flags: client
+      - name: Upload coverage to Codecov - Testcontainers
+        uses: codecov/codecov-action@11d69070bf0bb19a473235e011c7890707db52de # v2.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./lowkey-vault-testcontainers/build/reports/jacoco/report.xml
+          flags: testcontainers

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -15,6 +15,8 @@ on:
       - 'LICENSE'
       - '.github/ISSUE_TEMPLATE/**'
       - '.github/assets/**'
+      - '.github/dependabot.yml'
+      - '.github/workflows/**'
 
 permissions: read-all
 
@@ -67,3 +69,16 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./lowkey-vault-app/build/reports/jacoco/report.xml
+          flags: app
+      - name: Upload coverage to Codecov - Client
+        uses: codecov/codecov-action@11d69070bf0bb19a473235e011c7890707db52de # v2.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./lowkey-vault-client/build/reports/jacoco/report.xml
+          flags: client
+      - name: Upload coverage to Codecov - Testcontainers
+        uses: codecov/codecov-action@11d69070bf0bb19a473235e011c7890707db52de # v2.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./lowkey-vault-testcontainers/build/reports/jacoco/report.xml
+          flags: testcontainers

--- a/README.md
+++ b/README.md
@@ -130,6 +130,14 @@ Lowkey Vault is far from supporting all Azure Key Vault features. The list suppo
 - Update secret
 - Recover deleted secret
 
+## Startup parameters
+
+### Log requests
+
+In order to support debugging integration, Lowkey Vault can log request data. To turn on this feature, 
+you must pass ```--LOWKEY_DEBUG_REQUEST_LOG=true``` as startup argument in the
+```LOWKEY_ARGS``` env variable when starting the Docker container. [Example](lowkey-vault-docker/build.gradle#L64)
+
 ### Non-default vaults
 
 In case you wish to use more than one vaults, you should consider registering additional vaults using
@@ -164,7 +172,6 @@ This issue should not happen while using Testcontainers. See examples under [Low
 # Limitations
 
 - Some encryption/signature algorithms are not supported. Please refer to the ["Features"](#features) section for the up-to-date list of supported algorithms.
-- ```EC``` public keys are not exposed by the server to make Azure Cryptography Client always go to the server during encrypt/verify operations.
 - Backup and restore features are not supported at the moment
 - Certificate Vault features are not supported at the moment
 - Recovery options cannot be set as vault creation is implicit during start-up

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-    id 'io.toolebox.git-versioner' version '1.6.5'
-    id 'org.sonatype.gradle.plugins.scan' version '2.2.2' apply false
-    id 'org.owasp.dependencycheck' version '6.5.2' apply false
+    id 'io.toolebox.git-versioner' version '1.6.7'
+    id 'org.sonatype.gradle.plugins.scan' version '2.2.3' apply false
+    id 'org.owasp.dependencycheck' version '6.5.3' apply false
 }
 
 group = 'com.github.nagyesta.lowkey-vault'

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,4 +3,23 @@ coverage:
     project:
       default:
         threshold: 0.50%
-    patch: off
+      app:
+        flags:
+        - app
+      client:
+        flags:
+        - client
+      testcontainers:
+        flags:
+        - testcontainers
+    patch: false
+flags:
+  app:
+    paths:
+      - ./lowkey-vault-app
+  client:
+    paths:
+      - ./lowkey-vault-client
+  testcontainers:
+    paths:
+      - ./lowkey-vault-testcontainers

--- a/lowkey-vault-app/README.md
+++ b/lowkey-vault-app/README.md
@@ -5,7 +5,7 @@
 [![latest-release](https://img.shields.io/github/v/tag/nagyesta/lowkey-vault?color=blue&logo=git&label=releases&sort=semver)](https://github.com/nagyesta/lowkey-vault/releases)
 [![Docker Hub](https://img.shields.io/docker/v/nagyesta/lowkey-vault?label=docker%20hub&logo=docker&sort=semver)](https://hub.docker.com/repository/docker/nagyesta/lowkey-vault)
 [![JavaCI](https://img.shields.io/github/workflow/status/nagyesta/lowkey-vault/JavaCI?logo=github)](https://img.shields.io/github/workflow/status/nagyesta/lowkey-vault/JavaCI?logo=github)
-[![codecov](https://img.shields.io/codecov/c/github/nagyesta/lowkey-vault?label=Coverage&token=3ZZ9Q4S5WW)](https://img.shields.io/codecov/c/github/nagyesta/lowkey-vault?label=Coverage&token=3ZZ9Q4S5WW)
+[![codecov](https://img.shields.io/codecov/c/github/nagyesta/lowkey-vault?label=Coverage&flag=app&token=3ZZ9Q4S5WW)](https://img.shields.io/codecov/c/github/nagyesta/lowkey-vault?label=Coverage&flag=app&token=3ZZ9Q4S5WW)
 [![badge-abort-mission-armed-green](https://raw.githubusercontent.com/nagyesta/abort-mission/wiki_assets/.github/assets/badge-abort-mission-armed-green.svg)](https://github.com/nagyesta/abort-mission)
 
 # Lowkey Vault - App

--- a/lowkey-vault-app/build.gradle
+++ b/lowkey-vault-app/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'org.springframework.boot' version '2.5.5'
     id 'java'
     //noinspection SpellCheckingInspection
-    id "io.freefair.lombok" version '6.2.0'
+    id 'io.freefair.lombok' version '6.4.0'
     id 'com.github.nagyesta.abort-mission-gradle-plugin' version '2.1.0'
 }
 

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/AppConfiguration.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/AppConfiguration.java
@@ -4,9 +4,11 @@ import com.github.nagyesta.lowkeyvault.service.vault.VaultService;
 import com.github.nagyesta.lowkeyvault.service.vault.impl.VaultServiceImpl;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.util.StringUtils;
+import org.springframework.web.filter.CommonsRequestLoggingFilter;
 
 import java.net.URI;
 import java.util.Arrays;
@@ -17,6 +19,7 @@ import java.util.stream.Stream;
 @Slf4j
 public class AppConfiguration {
 
+    private static final int PAYLOAD_LENGTH_BYTES = 512 * 1024;
     @Value("${LOWKEY_VAULT_NAMES:primary,secondary}")
     private String autoRegisterVaults;
     @Value("${server.port}")
@@ -44,5 +47,16 @@ public class AppConfiguration {
         log.info("Vaults registered!");
 
         return service;
+    }
+
+    @Bean
+    @ConditionalOnExpression("${LOWKEY_DEBUG_REQUEST_LOG:false}")
+    public CommonsRequestLoggingFilter requestLoggingFilter() {
+        final CommonsRequestLoggingFilter requestLoggingFilter = new CommonsRequestLoggingFilter();
+        requestLoggingFilter.setIncludeClientInfo(true);
+        requestLoggingFilter.setIncludeQueryString(true);
+        requestLoggingFilter.setIncludePayload(true);
+        requestLoggingFilter.setMaxPayloadLength(PAYLOAD_LENGTH_BYTES);
+        return requestLoggingFilter;
     }
 }

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/mapper/v7_2/key/KeyEntityToV72ModelConverter.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/mapper/v7_2/key/KeyEntityToV72ModelConverter.java
@@ -57,7 +57,8 @@ public class KeyEntityToV72ModelConverter
     private JsonWebKeyModel mapEcFields(final ReadOnlyEcKeyVaultKeyEntity entity) {
         final JsonWebKeyModel jsonWebKeyModel = mapCommonKeyProperties(entity);
         jsonWebKeyModel.setCurveName(entity.getKeyCurveName());
-        //skip mapping X and Y to not expose public key to client
+        jsonWebKeyModel.setX(entity.getX());
+        jsonWebKeyModel.setY(entity.getY());
         return jsonWebKeyModel;
     }
 

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/model/v7_2/key/constants/SignatureAlgorithm.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/model/v7_2/key/constants/SignatureAlgorithm.java
@@ -9,28 +9,52 @@ import java.util.Arrays;
 @SuppressWarnings("checkstyle:JavadocVariable")
 public enum SignatureAlgorithm {
 
-    ES256("ES256", "NONEwithECDSA", KeyType.EC) {
+    ES256("ES256", "NONEwithECDSAinP1363Format", KeyType.EC) {
         @Override
         public boolean isCompatibleWithCurve(final KeyCurveName keyCurveName) {
             return KeyCurveName.P_256 == keyCurveName;
         }
+
+        @SuppressWarnings("checkstyle:MagicNumber")
+        @Override
+        public boolean supportsDigestLength(final int digestLength) {
+            return digestLength == 32;
+        }
     },
-    ES256K("ES256K", "NONEwithECDSA", KeyType.EC) {
+    ES256K("ES256K", "NONEwithECDSAinP1363Format", KeyType.EC) {
         @Override
         public boolean isCompatibleWithCurve(final KeyCurveName keyCurveName) {
             return KeyCurveName.P_256K == keyCurveName;
         }
+
+        @SuppressWarnings("checkstyle:MagicNumber")
+        @Override
+        public boolean supportsDigestLength(final int digestLength) {
+            return digestLength == 32;
+        }
     },
-    ES384("ES384", "NONEwithECDSA", KeyType.EC) {
+    ES384("ES384", "NONEwithECDSAinP1363Format", KeyType.EC) {
         @Override
         public boolean isCompatibleWithCurve(final KeyCurveName keyCurveName) {
             return KeyCurveName.P_384 == keyCurveName;
         }
+
+        @SuppressWarnings("checkstyle:MagicNumber")
+        @Override
+        public boolean supportsDigestLength(final int digestLength) {
+            return digestLength == 48;
+        }
     },
-    ES512("ES512", "NONEwithECDSA", KeyType.EC) {
+    ES512("ES512", "NONEwithECDSAinP1363Format", KeyType.EC) {
         @Override
         public boolean isCompatibleWithCurve(final KeyCurveName keyCurveName) {
             return KeyCurveName.P_521 == keyCurveName;
+        }
+
+        @SuppressWarnings("checkstyle:MagicNumber")
+        @Override
+        public boolean supportsDigestLength(final int digestLength) {
+            return digestLength == 64;
         }
     },
     PS256("PS256", "SHA256withRSAandMGF1", KeyType.RSA),
@@ -73,6 +97,11 @@ public enum SignatureAlgorithm {
 
     @JsonIgnore
     public boolean isCompatibleWithCurve(final KeyCurveName keyCurveName) {
+        return false;
+    }
+
+    @JsonIgnore
+    public boolean supportsDigestLength(final int digestLength) {
         return false;
     }
 

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/key/ReadOnlyKeyVaultKeyEntity.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/key/ReadOnlyKeyVaultKeyEntity.java
@@ -29,9 +29,9 @@ public interface ReadOnlyKeyVaultKeyEntity extends BaseVaultEntity<VersionedKeyE
 
     byte[] decryptToBytes(byte[] encrypted, EncryptionAlgorithm encryptionAlgorithm, byte[] iv);
 
-    byte[] signBytes(byte[] clear, SignatureAlgorithm encryptionAlgorithm);
+    byte[] signBytes(byte[] digest, SignatureAlgorithm encryptionAlgorithm);
 
-    boolean verifySignedBytes(byte[] signed, SignatureAlgorithm encryptionAlgorithm, byte[] digest);
+    boolean verifySignedBytes(byte[] digest, SignatureAlgorithm encryptionAlgorithm, byte[] signature);
 
     VersionedKeyEntityId getId();
 

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/key/impl/AesKeyVaultKeyEntity.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/key/impl/AesKeyVaultKeyEntity.java
@@ -83,14 +83,14 @@ public class AesKeyVaultKeyEntity extends KeyVaultKeyEntity<SecretKey, Integer> 
     }
 
     @Override
-    public byte[] signBytes(final byte[] clear, final SignatureAlgorithm encryptionAlgorithm) {
+    public byte[] signBytes(final byte[] digest, final SignatureAlgorithm encryptionAlgorithm) {
         throw new UnsupportedOperationException("Sign is not supported for OCT keys.");
     }
 
     @Override
-    public boolean verifySignedBytes(final byte[] signed,
+    public boolean verifySignedBytes(final byte[] digest,
                                      final SignatureAlgorithm encryptionAlgorithm,
-                                     final byte[] digest) {
+                                     final byte[] signature) {
         throw new UnsupportedOperationException("Verify is not supported for OCT keys.");
     }
 }

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/key/impl/RsaKeyVaultKeyEntity.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/key/impl/RsaKeyVaultKeyEntity.java
@@ -87,28 +87,28 @@ public class RsaKeyVaultKeyEntity extends KeyVaultKeyEntity<KeyPair, Integer> im
     }
 
     @Override
-    public byte[] signBytes(final byte[] clear, final SignatureAlgorithm signatureAlgorithm) {
+    public byte[] signBytes(final byte[] digest, final SignatureAlgorithm signatureAlgorithm) {
         Assert.state(getOperations().contains(KeyOperation.SIGN), getId() + " does not have SIGN operation assigned.");
         Assert.state(isEnabled(), getId() + " is not enabled.");
         return doCrypto(() -> {
             final Signature rsaSign = Signature.getInstance(signatureAlgorithm.getAlg(), new BouncyCastleProvider());
             rsaSign.initSign(getKey().getPrivate());
-            rsaSign.update(clear);
+            rsaSign.update(digest);
             return rsaSign.sign();
         }, "Cannot sign message.", log);
     }
 
     @Override
-    public boolean verifySignedBytes(final byte[] signed,
+    public boolean verifySignedBytes(final byte[] digest,
                                      final SignatureAlgorithm signatureAlgorithm,
-                                     final byte[] digest) {
+                                     final byte[] signature) {
         Assert.state(getOperations().contains(KeyOperation.VERIFY), getId() + " does not have VERIFY operation assigned.");
         Assert.state(isEnabled(), getId() + " is not enabled.");
         return doCrypto(() -> {
             final Signature rsaVerify = Signature.getInstance(signatureAlgorithm.getAlg(), new BouncyCastleProvider());
             rsaVerify.initVerify(getKey().getPublic());
-            rsaVerify.update(signed);
-            return rsaVerify.verify(digest);
-        }, "Cannot verify signed message.", log);
+            rsaVerify.update(digest);
+            return rsaVerify.verify(signature);
+        }, "Cannot verify digest message.", log);
     }
 }

--- a/lowkey-vault-app/src/main/resources/application.properties
+++ b/lowkey-vault-app/src/main/resources/application.properties
@@ -11,3 +11,5 @@ server.error.include-binding-errors=always
 server.error.include-message=always
 #
 spring.jackson.generator.flush-passed-to-stream=true
+#
+logging.level.org.springframework.web.filter.CommonsRequestLoggingFilter=DEBUG

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/mapper/v7_2/key/KeyEntityToV72ModelConverterTest.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/mapper/v7_2/key/KeyEntityToV72ModelConverterTest.java
@@ -143,6 +143,8 @@ class KeyEntityToV72ModelConverterTest {
             Assertions.assertEquals(KeyType.EC, actual.getKey().getKeyType());
         }
         Assertions.assertEquals(input.getKeyCurveName(), actual.getKey().getCurveName());
+        Assertions.assertArrayEquals(input.getX(), actual.getKey().getX());
+        Assertions.assertArrayEquals(input.getY(), actual.getKey().getY());
         assertRsaFieldsAreNull(actual);
         assertOctFieldsAreNull(actual);
 

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/model/v7_2/key/constants/SignatureAlgorithmTest.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/model/v7_2/key/constants/SignatureAlgorithmTest.java
@@ -32,6 +32,19 @@ class SignatureAlgorithmTest {
         Assertions.assertFalse(actual);
     }
 
+
+    @Test
+    void testSupportsDigestLengthShouldReturnFalseInCaseOfRsaAlgorithm() {
+        //given
+        final SignatureAlgorithm underTest = SignatureAlgorithm.PS256;
+
+        //when
+        final boolean actual = underTest.supportsDigestLength(0);
+
+        //then
+        Assertions.assertFalse(actual);
+    }
+
     @ParameterizedTest
     @MethodSource("valueProvider")
     void forValue(final String inout, final SignatureAlgorithm expected) {

--- a/lowkey-vault-client/README.md
+++ b/lowkey-vault-client/README.md
@@ -5,7 +5,7 @@
 [![latest-release](https://img.shields.io/github/v/tag/nagyesta/lowkey-vault?color=blue&logo=git&label=releases&sort=semver)](https://github.com/nagyesta/lowkey-vault/releases)
 [![Docker Hub](https://img.shields.io/docker/v/nagyesta/lowkey-vault?label=docker%20hub&logo=docker&sort=semver)](https://hub.docker.com/repository/docker/nagyesta/lowkey-vault)
 [![JavaCI](https://img.shields.io/github/workflow/status/nagyesta/lowkey-vault/JavaCI?logo=github)](https://img.shields.io/github/workflow/status/nagyesta/lowkey-vault/JavaCI?logo=github)
-[![codecov](https://img.shields.io/codecov/c/github/nagyesta/lowkey-vault?label=Coverage&token=3ZZ9Q4S5WW)](https://img.shields.io/codecov/c/github/nagyesta/lowkey-vault?label=Coverage&token=3ZZ9Q4S5WW)
+[![codecov](https://img.shields.io/codecov/c/github/nagyesta/lowkey-vault?label=Coverage&flag=client&token=3ZZ9Q4S5WW)](https://img.shields.io/codecov/c/github/nagyesta/lowkey-vault?label=Coverage&flag=client&token=3ZZ9Q4S5WW)
 [![badge-abort-mission-armed-green](https://raw.githubusercontent.com/nagyesta/abort-mission/wiki_assets/.github/assets/badge-abort-mission-armed-green.svg)](https://github.com/nagyesta/abort-mission)
 
 # Lowkey Vault - Client

--- a/lowkey-vault-docker/build.gradle
+++ b/lowkey-vault-docker/build.gradle
@@ -61,7 +61,7 @@ dockerRun {
     ports "8444:8443"
     daemonize true
     arguments '--rm'
-    env 'LOWKEY_ARGS': '--LOWKEY_VAULT_NAMES=keys-generic,keys-delete,' +
+    env 'LOWKEY_ARGS': '--LOWKEY_DEBUG_REQUEST_LOG=false --LOWKEY_VAULT_NAMES=keys-generic,keys-delete,' +
             'keys-list-rsa-1,keys-list-rsa-2,keys-list-rsa-3,keys-list-rsa-5,keys-list-rsa-25,keys-list-rsa-42,' +
             'keys-list-oct-1,keys-list-oct-2,keys-list-oct-3,keys-list-oct-5,keys-list-oct-25,keys-list-oct-42,' +
             'keys-list-ec-1,keys-list-ec-2,keys-list-ec-3,keys-list-ec-5,keys-list-ec-25,keys-list-ec-42,' +

--- a/lowkey-vault-docker/src/test/java/com/github/nagyesta/lowkeyvault/steps/KeysStepDefs.java
+++ b/lowkey-vault-docker/src/test/java/com/github/nagyesta/lowkeyvault/steps/KeysStepDefs.java
@@ -271,7 +271,7 @@ public class KeysStepDefs extends CommonAssertions {
     public void theCreatedKeyIsUsedToSignClearTextWithAlgorithm(final byte[] text, final SignatureAlgorithm algorithm) {
         final String keyId = context.getLastResult().getKey().getId();
         context.setCryptographyClient(context.getProvider().getCryptoClient(keyId));
-        final byte[] digest = hash(text);
+        final byte[] digest = hash(text, algorithm.toString());
         final SignResult signResult = context.getCryptographyClient()
                 .sign(algorithm, digest);
         context.setSignatureResult(signResult.getSignature());
@@ -302,14 +302,14 @@ public class KeysStepDefs extends CommonAssertions {
     public void theSignValueIsVerifiedWithAlgorithm(final byte[] text, final SignatureAlgorithm algorithm) {
         final String keyId = context.getLastResult().getKey().getId();
         context.setCryptographyClient(context.getProvider().getCryptoClient(keyId));
-        final byte[] digest = hash(text);
+        final byte[] digest = hash(text, algorithm.toString());
         final VerifyResult verifyResult = context.getCryptographyClient().verify(algorithm, digest, context.getSignatureResult());
         context.setVerifyResult(verifyResult.isValid());
     }
 
-    private byte[] hash(final byte[] text) {
+    private byte[] hash(final byte[] text, final String algorithm) {
         try {
-            final MessageDigest md = MessageDigest.getInstance("SHA-256");
+            final MessageDigest md = MessageDigest.getInstance("SHA-" + algorithm.substring(2, 5));
             md.update(text);
             return md.digest();
         } catch (final NoSuchAlgorithmException e) {

--- a/lowkey-vault-testcontainers/README.md
+++ b/lowkey-vault-testcontainers/README.md
@@ -5,7 +5,7 @@
 [![latest-release](https://img.shields.io/github/v/tag/nagyesta/lowkey-vault?color=blue&logo=git&label=releases&sort=semver)](https://github.com/nagyesta/lowkey-vault/releases)
 [![Docker Hub](https://img.shields.io/docker/v/nagyesta/lowkey-vault?label=docker%20hub&logo=docker&sort=semver)](https://hub.docker.com/repository/docker/nagyesta/lowkey-vault)
 [![JavaCI](https://img.shields.io/github/workflow/status/nagyesta/lowkey-vault/JavaCI?logo=github)](https://img.shields.io/github/workflow/status/nagyesta/lowkey-vault/JavaCI?logo=github)
-[![codecov](https://img.shields.io/codecov/c/github/nagyesta/lowkey-vault?label=Coverage&token=3ZZ9Q4S5WW)](https://img.shields.io/codecov/c/github/nagyesta/lowkey-vault?label=Coverage&token=3ZZ9Q4S5WW)
+[![codecov](https://img.shields.io/codecov/c/github/nagyesta/lowkey-vault?label=Coverage&flag=testcontainers&token=3ZZ9Q4S5WW)](https://img.shields.io/codecov/c/github/nagyesta/lowkey-vault?label=Coverage&flag=testcontainers&token=3ZZ9Q4S5WW)
 [![badge-abort-mission-armed-green](https://raw.githubusercontent.com/nagyesta/abort-mission/wiki_assets/.github/assets/badge-abort-mission-armed-green.svg)](https://github.com/nagyesta/abort-mission)
 
 # Lowkey Vault - Testcontainers


### PR DESCRIPTION
- Adds new startup parameter turning on/off request logging
- Updates workflows to prevent triggering them in case of unrelated workflow changes
- Separates codecov coverages of subprojects
- Fixes EC key sign/verify operations
- Restores EC key mapping to return public key X, Y components
- Updates gradle plugin versions

Resolves #21
{patch}