### PR TITLE
Update README to include a link to all available Docker tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ I have an app using Azure Key Vault and:
 ### Docker
 
 1. Pull the most recent version from ```nagyesta/lowkey-vault```
+   - You can find a list of all the available tags [here](https://hub.docker.com/r/nagyesta/lowkey-vault/tags)
 2. ```docker run --rm  -p 8443:8443 nagyesta/lowkey-vault:<version>```
 3. Use ```https://localhost:8443``` as key vault URI when using
    the [Azure Key Vault Key client](https://docs.microsoft.com/en-us/azure/key-vault/keys/quick-create-java)


### PR DESCRIPTION
__Issue:__ N/A

### Description
Running the command `docker pull nagyesta/lowkey-vault` results in the following error:
```
Error response from daemon: manifest for nagyesta/lowkey-vault:latest not found: manifest unknown: manifest unknown
```
This is because there doesn't exist a `latest` tag for Docker to pull, so tags must be explicitly provided to Docker in order to pull. If the lack of a `latest` tag is intentional, I think providing a link to a list of all available tags would make it easy for developers. 


### Entry point
README.md

### Checklists

- [x] I have rebased my branch
- [x] My commit message is meaningful
- [x] The commit messages use semantic versioning: ```{major}```, ```{minor}``` or ```{patch}```
- [x] The changes are focusing on the issue at hand
- [x] I have maintained or increased test coverage

### Notes
N/A