### PR TITLE
Wrong type for jackson-bom dependency in lowkey-vault-client

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -100,7 +100,7 @@ spring-boot-app = [
 spring-test = ["spring-boot-starter-test", "spring-test"]
 logback = ["logback-classic", "logback-core"]
 cucumber = ["cucumber-java", "cucumber-testng", "cucumber-spring"]
-jackson = ["jackson-bom", "jackson-core", "jackson-annotations", "jackson-databind", "jackson-dataformat-xml", "jackson-datatype-jsr310"]
+jackson = ["jackson-core", "jackson-annotations", "jackson-databind", "jackson-dataformat-xml", "jackson-datatype-jsr310"]
 tomcat = [
     "tomcat-annotations-api", "tomcat-jsp-api", "tomcat-embed-core", "tomcat-embed-el", "tomcat-embed-jasper", "tomcat-embed-websocket"
 ]

--- a/lowkey-vault-client/build.gradle
+++ b/lowkey-vault-client/build.gradle
@@ -17,6 +17,7 @@ dependencies {
     implementation(libs.azure.security.keyvault.secrets) {
         exclude(group: "io.netty")
     }
+    implementation "com.fasterxml.jackson:jackson-bom:${libs.versions.jacksonBom.get()}@pom"
     implementation libs.bundles.jackson
     implementation libs.httpclient
     implementation libs.commons.codec


### PR DESCRIPTION
__Issue:__ #258 

### Description
<!-- A short summary of changes -->

- Sets Jackson BOM dependency to use POM type in generated POM

### Entry point
<!-- Where should the reviewer start in order to properly understand the PR? -->

-

### Checklists

- [x] I have rebased my branch
- [x] My commit message is meaningful
- [x] The commit messages use semantic versioning: ```{major}```, ```{minor}``` or ```{patch}```
- [x] The changes are focusing on the issue at hand
- [x] I have maintained or increased test coverage

### Notes

-
<!-- Any additional remarks you may have. -->
