### PR TITLE
Certificate API - Save original certificate properties for later use - 05

### DIFF
--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/mapper/v7_3/certificate/CertificateEntityToV73PolicyModelConverter.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/mapper/v7_3/certificate/CertificateEntityToV73PolicyModelConverter.java
@@ -3,7 +3,7 @@ package com.github.nagyesta.lowkeyvault.mapper.v7_3.certificate;
 import com.github.nagyesta.lowkeyvault.mapper.AliasAwareConverter;
 import com.github.nagyesta.lowkeyvault.model.v7_3.certificate.*;
 import com.github.nagyesta.lowkeyvault.service.certificate.ReadOnlyKeyVaultCertificateEntity;
-import com.github.nagyesta.lowkeyvault.service.certificate.impl.CertificateCreationInput;
+import com.github.nagyesta.lowkeyvault.service.certificate.impl.ReadOnlyCertificatePolicy;
 import lombok.NonNull;
 import org.springframework.stereotype.Component;
 
@@ -46,26 +46,26 @@ public class CertificateEntityToV73PolicyModelConverter
 
     private IssuerParameterModel convertIssuer(final ReadOnlyKeyVaultCertificateEntity source) {
         final IssuerParameterModel issuerParameterModel = new IssuerParameterModel();
-        issuerParameterModel.setIssuer(source.getGenerator().getCertAuthorityType().getValue());
+        issuerParameterModel.setIssuer(source.getPolicy().getCertAuthorityType().getValue());
         issuerParameterModel.setCertType(null);
-        issuerParameterModel.setCertTransparency(source.getGenerator().isEnableTransparency());
+        issuerParameterModel.setCertTransparency(source.getPolicy().isEnableTransparency());
         return issuerParameterModel;
     }
 
     private X509CertificateModel convertX509Properties(final ReadOnlyKeyVaultCertificateEntity source) {
         final X509CertificateModel model = new X509CertificateModel();
-        final CertificateCreationInput generator = source.getGenerator();
-        model.setSubject(generator.getSubject());
-        model.setKeyUsage(generator.getKeyUsage());
-        model.setValidityMonths(generator.getValidityMonths());
-        model.setExtendedKeyUsage(generator.getExtendedKeyUsage());
-        model.setSubjectAlternativeNames(new SubjectAlternativeNames(generator.getDnsNames(), generator.getEmails(), generator.getIps()));
+        final ReadOnlyCertificatePolicy policy = source.getPolicy();
+        model.setSubject(policy.getSubject());
+        model.setKeyUsage(policy.getKeyUsage());
+        model.setValidityMonths(policy.getValidityMonths());
+        model.setExtendedKeyUsage(policy.getExtendedKeyUsage());
+        model.setSubjectAlternativeNames(new SubjectAlternativeNames(policy.getDnsNames(), policy.getEmails(), policy.getIps()));
         return model;
     }
 
     private CertificateSecretModel convertSecretProperties(final ReadOnlyKeyVaultCertificateEntity source) {
         final CertificateSecretModel model = new CertificateSecretModel();
-        model.setContentType(source.getGenerator().getContentType().getMimeType());
+        model.setContentType(source.getPolicy().getContentType().getMimeType());
         return model;
     }
 
@@ -78,13 +78,13 @@ public class CertificateEntityToV73PolicyModelConverter
     }
 
     private CertificateKeyModel convertKeyProperties(final ReadOnlyKeyVaultCertificateEntity source) {
-        final CertificateCreationInput generator = source.getGenerator();
+        final ReadOnlyCertificatePolicy policy = source.getPolicy();
         final CertificateKeyModel model = new CertificateKeyModel();
-        model.setExportable(generator.isExportablePrivateKey());
-        model.setReuseKey(generator.isReuseKeyOnRenewal());
-        model.setKeySize(generator.getKeySize());
-        model.setKeyCurveName(generator.getKeyCurveName());
-        model.setKeyType(generator.getKeyType());
+        model.setExportable(policy.isExportablePrivateKey());
+        model.setReuseKey(policy.isReuseKeyOnRenewal());
+        model.setKeySize(policy.getKeySize());
+        model.setKeyCurveName(policy.getKeyCurveName());
+        model.setKeyType(policy.getKeyType());
         return model;
     }
 

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/certificate/ReadOnlyKeyVaultCertificateEntity.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/certificate/ReadOnlyKeyVaultCertificateEntity.java
@@ -1,7 +1,7 @@
 package com.github.nagyesta.lowkeyvault.service.certificate;
 
 import com.github.nagyesta.lowkeyvault.service.certificate.id.VersionedCertificateEntityId;
-import com.github.nagyesta.lowkeyvault.service.certificate.impl.CertificateCreationInput;
+import com.github.nagyesta.lowkeyvault.service.certificate.impl.ReadOnlyCertificatePolicy;
 import com.github.nagyesta.lowkeyvault.service.common.BaseVaultEntity;
 import com.github.nagyesta.lowkeyvault.service.key.ReadOnlyDeletedEntity;
 import com.github.nagyesta.lowkeyvault.service.key.id.VersionedKeyEntityId;
@@ -21,7 +21,11 @@ public interface ReadOnlyKeyVaultCertificateEntity
 
     Certificate getCertificate();
 
-    CertificateCreationInput getGenerator();
+    ReadOnlyCertificatePolicy getPolicy();
+
+    ReadOnlyCertificatePolicy getOriginalCertificateData();
+
+    String getOriginalCertificateContents();
 
     PKCS10CertificationRequest getCertificateSigningRequest();
 

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/certificate/impl/CertificateCreationInput.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/certificate/impl/CertificateCreationInput.java
@@ -2,19 +2,15 @@ package com.github.nagyesta.lowkeyvault.service.certificate.impl;
 
 import com.github.nagyesta.lowkeyvault.model.v7_2.key.constants.KeyCurveName;
 import com.github.nagyesta.lowkeyvault.model.v7_2.key.constants.KeyType;
-import com.github.nagyesta.lowkeyvault.model.v7_2.key.request.CreateKeyRequest;
-import com.github.nagyesta.lowkeyvault.service.key.impl.KeyCreationInput;
 import lombok.Data;
 import lombok.NonNull;
 import lombok.ToString;
 
 import java.time.OffsetDateTime;
-import java.time.temporal.ChronoUnit;
-import java.util.Date;
 import java.util.Set;
 
 @Data
-public class CertificateCreationInput {
+public class CertificateCreationInput implements ReadOnlyCertificatePolicy {
 
     /**
      * Default number of months used for certificate validity.
@@ -62,23 +58,6 @@ public class CertificateCreationInput {
 
     public static CertificateCreationInputBuilder builder() {
         return new CertificateCreationInputBuilder();
-    }
-
-    public KeyCreationInput<?> toKeyCreationInput() {
-        final CreateKeyRequest request = new CreateKeyRequest();
-        request.setKeyType(getKeyType());
-        request.setKeySize(getKeySize());
-        request.setKeyCurveName(getKeyCurveName());
-        return request.toKeyCreationInput();
-    }
-
-    public Date certNotBefore() {
-        return Date.from(validityStart.truncatedTo(ChronoUnit.DAYS).toInstant());
-    }
-
-
-    public Date certExpiry() {
-        return Date.from(validityStart.plusMonths(validityMonths).truncatedTo(ChronoUnit.DAYS).toInstant());
     }
 
     @ToString

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/certificate/impl/CertificateGenerator.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/certificate/impl/CertificateGenerator.java
@@ -63,7 +63,7 @@ public class CertificateGenerator {
     }
 
     public PKCS10CertificationRequest generateCertificateSigningRequest(
-            @NonNull final CertificateCreationInput input) throws CryptoException {
+            @NonNull final ReadOnlyCertificatePolicy input) throws CryptoException {
         try {
             final ReadOnlyAsymmetricKeyVaultKeyEntity readOnlyKeyVaultKey = vault.keyVaultFake().getEntities()
                     .getEntity(kid, ReadOnlyAsymmetricKeyVaultKeyEntity.class);
@@ -145,7 +145,7 @@ public class CertificateGenerator {
         return certificate.build(signer);
     }
 
-    X500Name generateSubject(final CertificateCreationInput input) {
+    X500Name generateSubject(final ReadOnlyCertificatePolicy input) {
         final RDN[] rdns = IETFUtils.rDNsFromString(input.getSubject(), BCStyle.INSTANCE);
         final X500NameBuilder x500NameBuilder = new X500NameBuilder(BCStyle.INSTANCE);
         Arrays.stream(rdns).map(RDN::getTypesAndValues).forEach(x500NameBuilder::addMultiValuedRDN);

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/certificate/impl/CertificateImportInput.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/certificate/impl/CertificateImportInput.java
@@ -1,33 +1,24 @@
 package com.github.nagyesta.lowkeyvault.service.certificate.impl;
 
-import com.github.nagyesta.lowkeyvault.mapper.v7_2.key.EcJsonWebKeyImportRequestConverter;
-import com.github.nagyesta.lowkeyvault.mapper.v7_2.key.RsaJsonWebKeyImportRequestConverter;
-import com.github.nagyesta.lowkeyvault.model.v7_2.key.constants.KeyCurveName;
 import com.github.nagyesta.lowkeyvault.model.v7_2.key.request.JsonWebKeyImportRequest;
 import com.github.nagyesta.lowkeyvault.model.v7_3.certificate.*;
+import com.github.nagyesta.lowkeyvault.service.certificate.impl.CertificateCreationInput.CertificateCreationInputBuilder;
+import com.github.nagyesta.lowkeyvault.service.certificate.util.ParserUtil;
 import lombok.Data;
 import lombok.NonNull;
-import org.bouncycastle.asn1.x509.GeneralName;
 import org.springframework.lang.Nullable;
 
-import java.security.cert.CertificateParsingException;
 import java.security.cert.X509Certificate;
-import java.time.Instant;
-import java.time.ZoneOffset;
-import java.time.temporal.ChronoUnit;
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.Collectors;
+import java.util.function.Consumer;
 
 @Data
 public class CertificateImportInput {
 
-    private static final long HOURS_IN_MONTH = 730L;
     private final String name;
-    private final CertificateCreationInput certificateData;
+    private final CertificatePolicy certificateData;
+    private final CertificateCreationInput parsedCertificateData;
 
     private final JsonWebKeyImportRequest keyData;
 
@@ -44,103 +35,60 @@ public class CertificateImportInput {
         this.certificate = (X509Certificate) contentType.getCertificateChain(certificateContent, password).get(0);
         this.keyData = contentType.getKey(certificateContent, password);
         this.policyModel = policyModel;
-        final X509CertificateModel attributes = Objects.requireNonNullElse(policyModel.getX509Properties(), new X509CertificateModel());
+        final CertificateCreationInputBuilder builder = parsedInputBuilder(name, contentType, certificate, keyData, policyModel);
+        this.parsedCertificateData = builder.build();
+        this.certificateData = mergePolicies(this.parsedCertificateData, policyModel);
+    }
+
+    private static CertificateCreationInputBuilder parsedInputBuilder(
+            final String name,
+            final CertContentType contentType,
+            final X509Certificate certificate,
+            final JsonWebKeyImportRequest keyData,
+            final CertificatePolicyModel policyModel) {
         final CertificateKeyModel keyProperties = Objects.requireNonNullElse(policyModel.getKeyProperties(), new CertificateKeyModel());
         final IssuerParameterModel issuer = Objects.requireNonNullElse(policyModel.getIssuer(), new IssuerParameterModel());
-        this.certificateData = CertificateCreationInput.builder()
+        return ParserUtil.parseCertProperties(certificate)
                 .name(name)
-                .certAuthorityType(CertAuthorityType.UNKNOWN)
-                .subject(Optional.ofNullable(attributes.getSubject()).orElse(certificate.getSubjectX500Principal().getName()))
-                .dnsNames(alternativeName(attributes, certificate, SubjectAlternativeNames::getDnsNames, GeneralName.dNSName))
-                .ips(alternativeName(attributes, certificate, SubjectAlternativeNames::getUpns, GeneralName.iPAddress))
-                .emails(alternativeName(attributes, certificate, SubjectAlternativeNames::getEmails, GeneralName.rfc822Name))
-                .validityMonths(validityMonths(attributes, certificate))
-                .validityStart(certificate.getNotBefore().toInstant().atOffset(ZoneOffset.UTC))
                 .contentType(contentType)
-                .reuseKeyOnRenewal(keyProperties.isReuseKey())
-                .exportablePrivateKey(keyProperties.isExportable())
-                .keyType(Objects.requireNonNullElse(keyProperties.getKeyType(), keyData.getKeyType()))
-                .keyCurveName(findKeyCurve(keyData, keyProperties))
-                .keySize(findKeySize(keyData, keyProperties))
-                .enableTransparency(issuer.isCertTransparency())
                 .certificateType(issuer.getCertType())
-                .keyUsage(Optional.ofNullable(attributes.getKeyUsage())
-                        .map(Set::copyOf)
-                        .orElse(KeyUsageEnum.parseBitString(certificate.getKeyUsage())))
-                .extendedKeyUsage(Optional.ofNullable(attributes.getExtendedKeyUsage())
-                        .map(Set::copyOf)
-                        .orElse(Set.copyOf(extendedKeyUsage())))
-                .build();
+                .enableTransparency(issuer.isCertTransparency())
+                .keySize(ParserUtil.findKeySize(keyData))
+                .keyCurveName(ParserUtil.findKeyCurve(keyData))
+                .keyType(keyData.getKeyType())
+                .exportablePrivateKey(keyProperties.isExportable())
+                .reuseKeyOnRenewal(keyProperties.isReuseKey());
     }
 
-    private List<String> extendedKeyUsage() {
-        try {
-            return Optional.ofNullable(certificate.getExtendedKeyUsage()).orElse(List.of());
-        } catch (final CertificateParsingException e) {
-            throw new IllegalArgumentException("Failed to get extended key usage.", e);
-        }
+    private static CertificatePolicy mergePolicies(
+            final CertificateCreationInput parsedCertificateData, final CertificatePolicyModel policyModel) {
+        final CertificatePolicy policy = new CertificatePolicy(parsedCertificateData);
+        Optional.ofNullable(policyModel.getKeyProperties())
+                .ifPresent(overrideKeyProperties(policy));
+        Optional.ofNullable(policyModel.getX509Properties())
+                .ifPresent(overrideX509Properties(policy));
+        return policy;
     }
 
-    private KeyCurveName findKeyCurve(final JsonWebKeyImportRequest keyImportRequest, final CertificateKeyModel keyProperties) {
-        if (!keyImportRequest.getKeyType().isEc()) {
-            return null;
-        }
-        return Optional.ofNullable(keyProperties.getKeyCurveName())
-                .orElseGet(() -> new EcJsonWebKeyImportRequestConverter().getKeyParameter(keyImportRequest));
+    private static Consumer<CertificateKeyModel> overrideKeyProperties(final CertificatePolicy policy) {
+        return k -> {
+            Optional.ofNullable(k.getKeyType()).ifPresent(policy::setKeyType);
+            Optional.ofNullable(k.getKeyCurveName()).ifPresent(policy::setKeyCurveName);
+            Optional.ofNullable(k.getKeySize()).ifPresent(policy::setKeySize);
+        };
     }
 
-    private Integer findKeySize(final JsonWebKeyImportRequest keyImportRequest, final CertificateKeyModel keyProperties) {
-        if (!keyImportRequest.getKeyType().isRsa()) {
-            return null;
-        }
-        return Optional.ofNullable(keyProperties.getKeySize())
-                .orElseGet(() -> new RsaJsonWebKeyImportRequestConverter().getKeyParameter(keyImportRequest));
-    }
-
-    private int validityMonths(final X509CertificateModel attributes, final X509Certificate certificate) {
-        final Instant notAfter = certificate.getNotAfter().toInstant();
-        final Instant notBefore = certificate.getNotBefore().toInstant();
-        return Optional.ofNullable(attributes.getValidityMonths())
-                .orElseGet(() -> calculateValidityMonths(notAfter, notBefore));
-    }
-
-    private int calculateValidityMonths(final Instant notAfter, final Instant notBefore) {
-        final Instant end = notAfter.minusSeconds(1);
-        int count = 1;
-        while (end.minus(count * HOURS_IN_MONTH, ChronoUnit.HOURS).isAfter(notBefore)) {
-            count++;
-        }
-        return count;
-    }
-
-    private static Set<String> alternativeName(final X509CertificateModel attributes,
-                                               final X509Certificate certificate,
-                                               final Function<SubjectAlternativeNames, Set<String>> function,
-                                               final int type) {
-        try {
-            final Set<String> names = getCertificateAlternativeNamesByType(certificate, type);
-            return findAlternativeName(attributes, function, names);
-        } catch (final CertificateParsingException e) {
-            throw new IllegalArgumentException("Failed to get alternative names by type: " + type, e);
-        }
-    }
-
-    private static Set<String> findAlternativeName(final X509CertificateModel attributes,
-                                                   final Function<SubjectAlternativeNames, Set<String>> function,
-                                                   final Set<String> defaultValue) {
-        return Optional.ofNullable(attributes.getSubjectAlternativeNames())
-                .map(function)
-                .map(Set::copyOf)
-                .orElse(defaultValue);
-    }
-
-    private static Set<String> getCertificateAlternativeNamesByType(final X509Certificate certificate, final int type)
-            throws CertificateParsingException {
-        return Optional.ofNullable(certificate.getSubjectAlternativeNames()).orElse(Set.of())
-                .stream()
-                .filter(l -> Objects.equals(type, l.get(0)))
-                .map(l -> (String) l.get(1))
-                .collect(Collectors.toSet());
+    private static Consumer<X509CertificateModel> overrideX509Properties(final CertificatePolicy policy) {
+        return x -> {
+            Optional.ofNullable(x.getSubject()).ifPresent(policy::setSubject);
+            final Optional<SubjectAlternativeNames> subjectAlternativeNames = Optional.ofNullable(x.getSubjectAlternativeNames());
+            subjectAlternativeNames.map(SubjectAlternativeNames::getDnsNames).ifPresent(policy::setDnsNames);
+            subjectAlternativeNames.map(SubjectAlternativeNames::getUpns).ifPresent(policy::setIps);
+            subjectAlternativeNames.map(SubjectAlternativeNames::getEmails).ifPresent(policy::setEmails);
+            Optional.ofNullable(x.getValidityMonths()).ifPresent(policy::setValidityMonths);
+            Optional.ofNullable(x.getKeyUsage()).ifPresent(policy::setKeyUsage);
+            Optional.ofNullable(x.getExtendedKeyUsage()).ifPresent(policy::setExtendedKeyUsage);
+        };
     }
 
 }

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/certificate/impl/CertificatePolicy.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/certificate/impl/CertificatePolicy.java
@@ -1,0 +1,73 @@
+package com.github.nagyesta.lowkeyvault.service.certificate.impl;
+
+import com.github.nagyesta.lowkeyvault.model.v7_2.key.constants.KeyCurveName;
+import com.github.nagyesta.lowkeyvault.model.v7_2.key.constants.KeyType;
+import lombok.Data;
+import lombok.NonNull;
+
+import java.time.OffsetDateTime;
+import java.util.Set;
+
+@Data
+public class CertificatePolicy implements ReadOnlyCertificatePolicy {
+
+    private String name;
+    private CertAuthorityType certAuthorityType;
+    private String subject;
+    private Set<String> dnsNames;
+    private Set<String> emails;
+    private Set<String> ips;
+    private int validityMonths;
+    private OffsetDateTime validityStart;
+    private CertContentType contentType;
+    private boolean reuseKeyOnRenewal;
+    private boolean exportablePrivateKey;
+    private KeyType keyType;
+    private KeyCurveName keyCurveName;
+    private Integer keySize;
+    private boolean enableTransparency;
+    private String certificateType;
+    private Set<KeyUsageEnum> keyUsage;
+    private Set<String> extendedKeyUsage;
+
+    public CertificatePolicy(@NonNull final ReadOnlyCertificatePolicy source) {
+        this.name = source.getName();
+        this.certAuthorityType = source.getCertAuthorityType();
+        this.subject = source.getSubject();
+        this.dnsNames = Set.copyOf(source.getDnsNames());
+        this.emails = Set.copyOf(source.getEmails());
+        this.ips = Set.copyOf(source.getIps());
+        this.validityMonths = source.getValidityMonths();
+        this.validityStart = source.getValidityStart();
+        this.contentType = source.getContentType();
+        this.reuseKeyOnRenewal = source.isReuseKeyOnRenewal();
+        this.exportablePrivateKey = source.isExportablePrivateKey();
+        this.keyType = source.getKeyType();
+        this.keyCurveName = source.getKeyCurveName();
+        this.keySize = source.getKeySize();
+        this.enableTransparency = source.isEnableTransparency();
+        this.certificateType = source.getCertificateType();
+        this.keyUsage = Set.copyOf(source.getKeyUsage());
+        this.extendedKeyUsage = Set.copyOf(source.getExtendedKeyUsage());
+    }
+
+    public void setDnsNames(@NonNull final Set<String> dnsNames) {
+        this.dnsNames = Set.copyOf(dnsNames);
+    }
+
+    public void setEmails(@NonNull final Set<String> emails) {
+        this.emails = Set.copyOf(emails);
+    }
+
+    public void setIps(@NonNull final Set<String> ips) {
+        this.ips = Set.copyOf(ips);
+    }
+
+    public void setKeyUsage(@NonNull final Set<KeyUsageEnum> keyUsage) {
+        this.keyUsage = Set.copyOf(keyUsage);
+    }
+
+    public void setExtendedKeyUsage(@NonNull final Set<String> extendedKeyUsage) {
+        this.extendedKeyUsage = Set.copyOf(extendedKeyUsage);
+    }
+}

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/certificate/impl/CertificateVaultFakeImpl.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/certificate/impl/CertificateVaultFakeImpl.java
@@ -36,7 +36,7 @@ public class CertificateVaultFakeImpl
     public VersionedCertificateEntityId importCertificateVersion(
             @NonNull final String name, @NonNull final CertificateImportInput input) {
         final KeyVaultCertificateEntity entity = new KeyVaultCertificateEntity(
-                name, input.getCertificateData(), input.getCertificate(), input.getKeyData(), vaultFake());
+                name, input, vaultFake());
         return addVersion(entity.getId(), entity);
     }
 }

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/certificate/impl/ReadOnlyCertificatePolicy.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/certificate/impl/ReadOnlyCertificatePolicy.java
@@ -1,0 +1,67 @@
+package com.github.nagyesta.lowkeyvault.service.certificate.impl;
+
+import com.github.nagyesta.lowkeyvault.model.v7_2.key.constants.KeyCurveName;
+import com.github.nagyesta.lowkeyvault.model.v7_2.key.constants.KeyType;
+import com.github.nagyesta.lowkeyvault.model.v7_2.key.request.CreateKeyRequest;
+import com.github.nagyesta.lowkeyvault.service.key.impl.KeyCreationInput;
+
+import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.Set;
+
+public interface ReadOnlyCertificatePolicy {
+
+    default KeyCreationInput<?> toKeyCreationInput() {
+        final CreateKeyRequest request = new CreateKeyRequest();
+        request.setKeyType(getKeyType());
+        request.setKeySize(getKeySize());
+        request.setKeyCurveName(getKeyCurveName());
+        return request.toKeyCreationInput();
+    }
+
+    default Date certNotBefore() {
+        return Date.from(getValidityStart().truncatedTo(ChronoUnit.DAYS).toInstant());
+    }
+
+
+    default Date certExpiry() {
+        return Date.from(getValidityStart().plusMonths(getValidityMonths()).truncatedTo(ChronoUnit.DAYS).toInstant());
+    }
+
+    String getName();
+
+    CertAuthorityType getCertAuthorityType();
+
+    String getSubject();
+
+    Set<String> getDnsNames();
+
+    Set<String> getEmails();
+
+    Set<String> getIps();
+
+    int getValidityMonths();
+
+    OffsetDateTime getValidityStart();
+
+    CertContentType getContentType();
+
+    boolean isReuseKeyOnRenewal();
+
+    boolean isExportablePrivateKey();
+
+    KeyType getKeyType();
+
+    KeyCurveName getKeyCurveName();
+
+    Integer getKeySize();
+
+    boolean isEnableTransparency();
+
+    String getCertificateType();
+
+    Set<KeyUsageEnum> getKeyUsage();
+
+    Set<String> getExtendedKeyUsage();
+}

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/certificate/util/ParserUtil.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/certificate/util/ParserUtil.java
@@ -1,0 +1,93 @@
+package com.github.nagyesta.lowkeyvault.service.certificate.util;
+
+import com.github.nagyesta.lowkeyvault.mapper.v7_2.key.EcJsonWebKeyImportRequestConverter;
+import com.github.nagyesta.lowkeyvault.mapper.v7_2.key.RsaJsonWebKeyImportRequestConverter;
+import com.github.nagyesta.lowkeyvault.model.v7_2.key.constants.KeyCurveName;
+import com.github.nagyesta.lowkeyvault.model.v7_2.key.request.JsonWebKeyImportRequest;
+import com.github.nagyesta.lowkeyvault.service.certificate.impl.CertAuthorityType;
+import com.github.nagyesta.lowkeyvault.service.certificate.impl.CertificateCreationInput;
+import com.github.nagyesta.lowkeyvault.service.certificate.impl.KeyUsageEnum;
+import org.bouncycastle.asn1.x509.GeneralName;
+
+import java.security.cert.CertificateParsingException;
+import java.security.cert.X509Certificate;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public final class ParserUtil {
+
+    private static final long HOURS_IN_MONTH = 730L;
+
+    private ParserUtil() {
+        throw new IllegalCallerException("Utility cannot be instantiated.");
+    }
+
+    public static CertificateCreationInput.CertificateCreationInputBuilder parseCertProperties(
+            final X509Certificate certificate) {
+        return CertificateCreationInput.builder()
+                .certAuthorityType(CertAuthorityType.UNKNOWN)
+                .subject(certificate.getSubjectX500Principal().getName())
+                .dnsNames(getCertificateAlternativeNamesByType(certificate, GeneralName.dNSName))
+                .ips(getCertificateAlternativeNamesByType(certificate, GeneralName.iPAddress))
+                .emails(getCertificateAlternativeNamesByType(certificate, GeneralName.rfc822Name))
+                .validityMonths(validityMonths(certificate))
+                .validityStart(certificate.getNotBefore().toInstant().atOffset(ZoneOffset.UTC))
+                .keyUsage(KeyUsageEnum.parseBitString(certificate.getKeyUsage()))
+                .extendedKeyUsage(Set.copyOf(extendedKeyUsage(certificate)));
+    }
+
+    public static KeyCurveName findKeyCurve(final JsonWebKeyImportRequest keyImportRequest) {
+        if (!keyImportRequest.getKeyType().isEc()) {
+            return null;
+        }
+        return new EcJsonWebKeyImportRequestConverter().getKeyParameter(keyImportRequest);
+    }
+
+    public static Integer findKeySize(final JsonWebKeyImportRequest keyImportRequest) {
+        if (!keyImportRequest.getKeyType().isRsa()) {
+            return null;
+        }
+        return new RsaJsonWebKeyImportRequestConverter().getKeyParameter(keyImportRequest);
+    }
+
+    private static List<String> extendedKeyUsage(final X509Certificate certificate) {
+        try {
+            return Optional.ofNullable(certificate.getExtendedKeyUsage()).orElse(List.of());
+        } catch (final CertificateParsingException e) {
+            throw new IllegalArgumentException("Failed to get extended key usage.", e);
+        }
+    }
+
+    private static int validityMonths(final X509Certificate certificate) {
+        final Instant notAfter = certificate.getNotAfter().toInstant();
+        final Instant notBefore = certificate.getNotBefore().toInstant();
+        return calculateValidityMonths(notAfter, notBefore);
+    }
+
+    private static int calculateValidityMonths(final Instant notAfter, final Instant notBefore) {
+        final Instant end = notAfter.minusSeconds(1);
+        int count = 1;
+        while (end.minus(count * HOURS_IN_MONTH, ChronoUnit.HOURS).isAfter(notBefore)) {
+            count++;
+        }
+        return count;
+    }
+
+    private static Set<String> getCertificateAlternativeNamesByType(final X509Certificate certificate, final int type) {
+        try {
+            return Optional.ofNullable(certificate.getSubjectAlternativeNames()).orElse(Set.of())
+                    .stream()
+                    .filter(l -> Objects.equals(type, l.get(0)))
+                    .map(l -> (String) l.get(1))
+                    .collect(Collectors.toSet());
+        } catch (final CertificateParsingException e) {
+            throw new IllegalArgumentException("Failed to get alternative names by type: " + type, e);
+        }
+    }
+}

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/service/certificate/impl/CertificatePolicyTest.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/service/certificate/impl/CertificatePolicyTest.java
@@ -1,0 +1,78 @@
+package com.github.nagyesta.lowkeyvault.service.certificate.impl;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class CertificatePolicyTest {
+
+    @SuppressWarnings("DataFlowIssue")
+    @Test
+    void testConstructorShouldThrowExceptionWhenCalledWithNull() {
+        //given
+
+        //when
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new CertificatePolicy(null));
+
+        //then + exception
+    }
+
+    @SuppressWarnings("DataFlowIssue")
+    @Test
+    void testSetDnsNamesShouldThrowExceptionWhenCalledWithNull() {
+        //given
+        final CertificatePolicy underTest = new CertificatePolicy(CertificateCreationInput.builder().build());
+
+        //when
+        Assertions.assertThrows(IllegalArgumentException.class, () -> underTest.setDnsNames(null));
+
+        //then + exception
+    }
+
+    @SuppressWarnings("DataFlowIssue")
+    @Test
+    void testSetIpsShouldThrowExceptionWhenCalledWithNull() {
+        //given
+        final CertificatePolicy underTest = new CertificatePolicy(CertificateCreationInput.builder().build());
+
+        //when
+        Assertions.assertThrows(IllegalArgumentException.class, () -> underTest.setIps(null));
+
+        //then + exception
+    }
+
+    @SuppressWarnings("DataFlowIssue")
+    @Test
+    void testSetEmailsShouldThrowExceptionWhenCalledWithNull() {
+        //given
+        final CertificatePolicy underTest = new CertificatePolicy(CertificateCreationInput.builder().build());
+
+        //when
+        Assertions.assertThrows(IllegalArgumentException.class, () -> underTest.setEmails(null));
+
+        //then + exception
+    }
+
+    @SuppressWarnings("DataFlowIssue")
+    @Test
+    void testSetKeyUsageShouldThrowExceptionWhenCalledWithNull() {
+        //given
+        final CertificatePolicy underTest = new CertificatePolicy(CertificateCreationInput.builder().build());
+
+        //when
+        Assertions.assertThrows(IllegalArgumentException.class, () -> underTest.setKeyUsage(null));
+
+        //then + exception
+    }
+
+    @SuppressWarnings("DataFlowIssue")
+    @Test
+    void testSetExtendedKeyUsageShouldThrowExceptionWhenCalledWithNull() {
+        //given
+        final CertificatePolicy underTest = new CertificatePolicy(CertificateCreationInput.builder().build());
+
+        //when
+        Assertions.assertThrows(IllegalArgumentException.class, () -> underTest.setExtendedKeyUsage(null));
+
+        //then + exception
+    }
+}

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/service/certificate/util/ParserUtilTest.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/service/certificate/util/ParserUtilTest.java
@@ -1,0 +1,22 @@
+package com.github.nagyesta.lowkeyvault.service.certificate.util;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+
+class ParserUtilTest {
+
+    @Test
+    void testConstructorShouldThrowExceptionWhenCalled() throws NoSuchMethodException {
+        //given
+        final Constructor<ParserUtil> constructor = ParserUtil.class.getDeclaredConstructor();
+        constructor.setAccessible(true);
+
+        //when
+        Assertions.assertThrows(InvocationTargetException.class, constructor::newInstance);
+
+        //then + exception
+    }
+}


### PR DESCRIPTION
__Issue:__ #441 

### Description
<!-- A short summary of changes -->

- Parses original certificate
- Saves parsed date for later use
- Keeps saving actual certificate policy in renamed field
- Adds new test cases

### Entry point
<!-- Where should the reviewer start in order to properly understand the PR? -->

-

### Checklists

- [x] I have rebased my branch
- [x] My commit message is meaningful
- [x] The commit messages use semantic versioning: ```{major}```, ```{minor}``` or ```{patch}```
- [x] The changes are focusing on the issue at hand
- [x] I have maintained or increased test coverage

### Notes

-
<!-- Any additional remarks you may have. -->
