### PR TITLE
Certificate API - Delete/recover/purge certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Lowkey Vault is far from supporting all Azure Key Vault features. The list suppo
     - Password used for PKCS12 stores: `lowkey-vault`
 - Get certificate operation
     - Get pending create operation results
+    - Get pending delete operation results
 - Get available certificate versions
 - Get certificate
     - Latest version of a single certificate
@@ -164,6 +165,12 @@ Lowkey Vault is far from supporting all Azure Key Vault features. The list suppo
 - Import certificate
     - Self-signed only
     - The downloadable certificate is protected using `lowkey-vault` as password for PKCS12 stores
+- Get deleted certificate
+    - Latest version of a single certificate
+    - List of all certificate
+- Delete certificate
+- Recover deleted certificate
+- Purge deleted certificate
 
 #### Warning!
 

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/controller/common/CommonKeyController.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/controller/common/CommonKeyController.java
@@ -99,7 +99,7 @@ public abstract class CommonKeyController extends GenericEntityController<KeyEnt
         return ResponseEntity.ok(getPageOfItems(baseUri, maxResults, skipToken, "/keys"));
     }
 
-    public ResponseEntity<KeyVaultItemListModel<KeyVaultKeyItemModel>> listDeletedKeys(
+    public ResponseEntity<KeyVaultItemListModel<DeletedKeyVaultKeyItemModel>> listDeletedKeys(
             final URI baseUri,
             final int maxResults,
             final int skipToken) {
@@ -145,7 +145,7 @@ public abstract class CommonKeyController extends GenericEntityController<KeyEnt
         return ResponseEntity.ok(getModelById(keyVaultFake, entityId, baseUri, true));
     }
 
-    public ResponseEntity<KeyVaultKeyModel> getDeletedKey(
+    public ResponseEntity<DeletedKeyVaultKeyModel> getDeletedKey(
             @Valid @Pattern(regexp = NAME_PATTERN) final String keyName,
             final URI baseUri) {
         log.info("Received request to {} get deleted key: {} using API version: {}",

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/controller/common/CommonSecretController.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/controller/common/CommonSecretController.java
@@ -49,7 +49,7 @@ public abstract class CommonSecretController extends GenericEntityController<Sec
         return ResponseEntity.ok(getModelById(secretVaultFake, secretEntityId, baseUri, true));
     }
 
-    public ResponseEntity<KeyVaultSecretModel> delete(
+    public ResponseEntity<DeletedKeyVaultSecretModel> delete(
             @Valid @Pattern(regexp = NAME_PATTERN) final String secretName,
             final URI baseUri) {
         log.info("Received request to {} delete secret: {} using API version: {}",
@@ -84,7 +84,7 @@ public abstract class CommonSecretController extends GenericEntityController<Sec
         return ResponseEntity.ok(getPageOfItems(baseUri, maxResults, skipToken, "/secrets"));
     }
 
-    public ResponseEntity<KeyVaultItemListModel<KeyVaultSecretItemModel>> listDeletedSecrets(
+    public ResponseEntity<KeyVaultItemListModel<DeletedKeyVaultSecretItemModel>> listDeletedSecrets(
             final URI baseUri,
             final int maxResults,
             final int skipToken) {

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/controller/common/GenericEntityController.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/controller/common/GenericEntityController.java
@@ -117,10 +117,10 @@ public abstract class GenericEntityController<K extends EntityId, V extends K, E
     }
 
     @SuppressWarnings("SameParameterValue")
-    protected KeyVaultItemListModel<I> getPageOfDeletedItems(final URI baseUri, final int limit, final int offset, final String uriPath) {
+    protected KeyVaultItemListModel<DI> getPageOfDeletedItems(final URI baseUri, final int limit, final int offset, final String uriPath) {
         final S entityVaultFake = getVaultByUri(baseUri);
         final List<E> allItems = entityVaultFake.getDeletedEntities().listLatestNonManagedEntities();
-        final List<I> items = filterList(limit, offset, allItems, source -> itemConverter.convertDeleted(source, baseUri));
+        final List<DI> items = filterList(limit, offset, allItems, source -> itemConverter.convertDeleted(source, baseUri));
         final URI nextUri = getNextUri(baseUri + uriPath, allItems, items, limit, offset);
         return listModel(items, nextUri);
     }
@@ -156,7 +156,7 @@ public abstract class GenericEntityController<K extends EntityId, V extends K, E
                 });
     }
 
-    protected KeyVaultItemListModel<I> listModel(final List<I> items, final URI nextUri) {
+    protected <LI> KeyVaultItemListModel<LI> listModel(final List<LI> items, final URI nextUri) {
         return new KeyVaultItemListModel<>(items, nextUri);
     }
 
@@ -169,8 +169,8 @@ public abstract class GenericEntityController<K extends EntityId, V extends K, E
         return nextUri;
     }
 
-    private <FR> List<I> filterList(
-            final int limit, final int offset, final Collection<FR> allItems, final Function<FR, I> mapper) {
+    private <FR, LI> List<LI> filterList(
+            final int limit, final int offset, final Collection<FR> allItems, final Function<FR, LI> mapper) {
         return allItems.stream()
                 .skip(offset)
                 .limit(limit)

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/controller/v7_2/KeyController.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/controller/v7_2/KeyController.java
@@ -6,6 +6,8 @@ import com.github.nagyesta.lowkeyvault.mapper.v7_2.key.KeyEntityToV72KeyVersionI
 import com.github.nagyesta.lowkeyvault.mapper.v7_2.key.KeyEntityToV72ModelConverter;
 import com.github.nagyesta.lowkeyvault.model.common.ApiConstants;
 import com.github.nagyesta.lowkeyvault.model.common.KeyVaultItemListModel;
+import com.github.nagyesta.lowkeyvault.model.v7_2.key.DeletedKeyVaultKeyItemModel;
+import com.github.nagyesta.lowkeyvault.model.v7_2.key.DeletedKeyVaultKeyModel;
 import com.github.nagyesta.lowkeyvault.model.v7_2.key.KeyVaultKeyItemModel;
 import com.github.nagyesta.lowkeyvault.model.v7_2.key.KeyVaultKeyModel;
 import com.github.nagyesta.lowkeyvault.model.v7_2.key.request.CreateKeyRequest;
@@ -48,9 +50,10 @@ public class KeyController extends CommonKeyController {
             params = API_VERSION_7_2,
             consumes = APPLICATION_JSON_VALUE,
             produces = APPLICATION_JSON_VALUE)
-    public ResponseEntity<KeyVaultKeyModel> create(@PathVariable @Valid @Pattern(regexp = NAME_PATTERN) final String keyName,
-                                                   @RequestAttribute(name = ApiConstants.REQUEST_BASE_URI) final URI baseUri,
-                                                   @Valid @RequestBody final CreateKeyRequest request) {
+    public ResponseEntity<KeyVaultKeyModel> create(
+            @PathVariable @Valid @Pattern(regexp = NAME_PATTERN) final String keyName,
+            @RequestAttribute(name = ApiConstants.REQUEST_BASE_URI) final URI baseUri,
+            @Valid @RequestBody final CreateKeyRequest request) {
         return super.create(keyName, baseUri, request);
     }
 
@@ -59,9 +62,10 @@ public class KeyController extends CommonKeyController {
             params = API_VERSION_7_2,
             consumes = APPLICATION_JSON_VALUE,
             produces = APPLICATION_JSON_VALUE)
-    public ResponseEntity<KeyVaultKeyModel> importKey(@PathVariable @Valid @Pattern(regexp = NAME_PATTERN) final String keyName,
-                                                      @RequestAttribute(name = ApiConstants.REQUEST_BASE_URI) final URI baseUri,
-                                                      @Valid @RequestBody final ImportKeyRequest request) {
+    public ResponseEntity<KeyVaultKeyModel> importKey(
+            @PathVariable @Valid @Pattern(regexp = NAME_PATTERN) final String keyName,
+            @RequestAttribute(name = ApiConstants.REQUEST_BASE_URI) final URI baseUri,
+            @Valid @RequestBody final ImportKeyRequest request) {
         return super.importKey(keyName, baseUri, request);
     }
 
@@ -69,8 +73,9 @@ public class KeyController extends CommonKeyController {
     @DeleteMapping(value = "/keys/{keyName}",
             params = API_VERSION_7_2,
             produces = APPLICATION_JSON_VALUE)
-    public ResponseEntity<KeyVaultKeyModel> delete(@PathVariable @Valid @Pattern(regexp = NAME_PATTERN) final String keyName,
-                                                   @RequestAttribute(name = ApiConstants.REQUEST_BASE_URI) final URI baseUri) {
+    public ResponseEntity<KeyVaultKeyModel> delete(
+            @PathVariable @Valid @Pattern(regexp = NAME_PATTERN) final String keyName,
+            @RequestAttribute(name = ApiConstants.REQUEST_BASE_URI) final URI baseUri) {
         return super.delete(keyName, baseUri);
     }
 
@@ -101,7 +106,7 @@ public class KeyController extends CommonKeyController {
     @GetMapping(value = "/deletedkeys",
             params = API_VERSION_7_2,
             produces = APPLICATION_JSON_VALUE)
-    public ResponseEntity<KeyVaultItemListModel<KeyVaultKeyItemModel>> listDeletedKeys(
+    public ResponseEntity<KeyVaultItemListModel<DeletedKeyVaultKeyItemModel>> listDeletedKeys(
             @RequestAttribute(name = ApiConstants.REQUEST_BASE_URI) final URI baseUri,
             @RequestParam(name = MAX_RESULTS_PARAM, required = false, defaultValue = DEFAULT_MAX) final int maxResults,
             @RequestParam(name = SKIP_TOKEN_PARAM, required = false, defaultValue = SKIP_ZERO) final int skipToken) {
@@ -146,8 +151,9 @@ public class KeyController extends CommonKeyController {
     @GetMapping(value = "/deletedkeys/{keyName}",
             params = API_VERSION_7_2,
             produces = APPLICATION_JSON_VALUE)
-    public ResponseEntity<KeyVaultKeyModel> getDeletedKey(@PathVariable @Valid @Pattern(regexp = NAME_PATTERN) final String keyName,
-                                                          @RequestAttribute(name = ApiConstants.REQUEST_BASE_URI) final URI baseUri) {
+    public ResponseEntity<DeletedKeyVaultKeyModel> getDeletedKey(
+            @PathVariable @Valid @Pattern(regexp = NAME_PATTERN) final String keyName,
+            @RequestAttribute(name = ApiConstants.REQUEST_BASE_URI) final URI baseUri) {
         return super.getDeletedKey(keyName, baseUri);
     }
 
@@ -155,8 +161,9 @@ public class KeyController extends CommonKeyController {
     @PostMapping(value = "/deletedkeys/{keyName}/recover",
             params = API_VERSION_7_2,
             produces = APPLICATION_JSON_VALUE)
-    public ResponseEntity<KeyVaultKeyModel> recoverDeletedKey(@PathVariable @Valid @Pattern(regexp = NAME_PATTERN) final String keyName,
-                                                              @RequestAttribute(name = ApiConstants.REQUEST_BASE_URI) final URI baseUri) {
+    public ResponseEntity<KeyVaultKeyModel> recoverDeletedKey(
+            @PathVariable @Valid @Pattern(regexp = NAME_PATTERN) final String keyName,
+            @RequestAttribute(name = ApiConstants.REQUEST_BASE_URI) final URI baseUri) {
         return super.recoverDeletedKey(keyName, baseUri);
     }
 
@@ -164,8 +171,9 @@ public class KeyController extends CommonKeyController {
     @DeleteMapping(value = "/deletedkeys/{keyName}",
             params = API_VERSION_7_2,
             produces = APPLICATION_JSON_VALUE)
-    public ResponseEntity<Void> purgeDeleted(@PathVariable @Valid @Pattern(regexp = NAME_PATTERN) final String keyName,
-                                             @RequestAttribute(name = ApiConstants.REQUEST_BASE_URI) final URI baseUri) {
+    public ResponseEntity<Void> purgeDeleted(
+            @PathVariable @Valid @Pattern(regexp = NAME_PATTERN) final String keyName,
+            @RequestAttribute(name = ApiConstants.REQUEST_BASE_URI) final URI baseUri) {
         return super.purgeDeleted(keyName, baseUri);
     }
 

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/controller/v7_2/SecretController.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/controller/v7_2/SecretController.java
@@ -6,6 +6,8 @@ import com.github.nagyesta.lowkeyvault.mapper.v7_2.secret.SecretEntityToV72Secre
 import com.github.nagyesta.lowkeyvault.mapper.v7_2.secret.SecretEntityToV72SecretVersionItemModelConverter;
 import com.github.nagyesta.lowkeyvault.model.common.ApiConstants;
 import com.github.nagyesta.lowkeyvault.model.common.KeyVaultItemListModel;
+import com.github.nagyesta.lowkeyvault.model.v7_2.secret.DeletedKeyVaultSecretItemModel;
+import com.github.nagyesta.lowkeyvault.model.v7_2.secret.DeletedKeyVaultSecretModel;
 import com.github.nagyesta.lowkeyvault.model.v7_2.secret.KeyVaultSecretItemModel;
 import com.github.nagyesta.lowkeyvault.model.v7_2.secret.KeyVaultSecretModel;
 import com.github.nagyesta.lowkeyvault.model.v7_2.secret.request.CreateSecretRequest;
@@ -48,9 +50,10 @@ public class SecretController extends CommonSecretController {
             params = API_VERSION_7_2,
             consumes = APPLICATION_JSON_VALUE,
             produces = APPLICATION_JSON_VALUE)
-    public ResponseEntity<KeyVaultSecretModel> create(@PathVariable @Valid @Pattern(regexp = NAME_PATTERN) final String secretName,
-                                                      @RequestAttribute(name = ApiConstants.REQUEST_BASE_URI) final URI baseUri,
-                                                      @Valid @RequestBody final CreateSecretRequest request) {
+    public ResponseEntity<KeyVaultSecretModel> create(
+            @PathVariable @Valid @Pattern(regexp = NAME_PATTERN) final String secretName,
+            @RequestAttribute(name = ApiConstants.REQUEST_BASE_URI) final URI baseUri,
+            @Valid @RequestBody final CreateSecretRequest request) {
         return super.create(secretName, baseUri, request);
     }
 
@@ -58,8 +61,9 @@ public class SecretController extends CommonSecretController {
     @DeleteMapping(value = "/secrets/{secretName}",
             params = API_VERSION_7_2,
             produces = APPLICATION_JSON_VALUE)
-    public ResponseEntity<KeyVaultSecretModel> delete(@PathVariable @Valid @Pattern(regexp = NAME_PATTERN) final String secretName,
-                                                      @RequestAttribute(name = ApiConstants.REQUEST_BASE_URI) final URI baseUri) {
+    public ResponseEntity<DeletedKeyVaultSecretModel> delete(
+            @PathVariable @Valid @Pattern(regexp = NAME_PATTERN) final String secretName,
+            @RequestAttribute(name = ApiConstants.REQUEST_BASE_URI) final URI baseUri) {
         return super.delete(secretName, baseUri);
     }
 
@@ -90,7 +94,7 @@ public class SecretController extends CommonSecretController {
     @GetMapping(value = "/deletedsecrets",
             params = API_VERSION_7_2,
             produces = APPLICATION_JSON_VALUE)
-    public ResponseEntity<KeyVaultItemListModel<KeyVaultSecretItemModel>> listDeletedSecrets(
+    public ResponseEntity<KeyVaultItemListModel<DeletedKeyVaultSecretItemModel>> listDeletedSecrets(
             @RequestAttribute(name = ApiConstants.REQUEST_BASE_URI) final URI baseUri,
             @RequestParam(name = MAX_RESULTS_PARAM, required = false, defaultValue = DEFAULT_MAX) final int maxResults,
             @RequestParam(name = SKIP_TOKEN_PARAM, required = false, defaultValue = SKIP_ZERO) final int skipToken) {

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/controller/v7_3/CertificateController.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/controller/v7_3/CertificateController.java
@@ -65,6 +65,16 @@ public class CertificateController extends CommonCertificateController {
     }
 
     @Override
+    @DeleteMapping(value = "/certificates/{certificateName}/pending",
+            params = API_VERSION_7_3,
+            produces = APPLICATION_JSON_VALUE)
+    public ResponseEntity<KeyVaultPendingCertificateModel> pendingDelete(
+            @PathVariable @Valid @Pattern(regexp = NAME_PATTERN) final String certificateName,
+            @RequestAttribute(name = ApiConstants.REQUEST_BASE_URI) final URI baseUri) {
+        return super.pendingDelete(certificateName, baseUri);
+    }
+
+    @Override
     @PostMapping(value = "/certificates/{certificateName}/import",
             params = API_VERSION_7_3,
             consumes = APPLICATION_JSON_VALUE,
@@ -108,6 +118,46 @@ public class CertificateController extends CommonCertificateController {
     }
 
     @Override
+    @DeleteMapping(value = "/certificates/{certificateName}",
+            params = API_VERSION_7_3,
+            produces = APPLICATION_JSON_VALUE)
+    public ResponseEntity<DeletedKeyVaultCertificateModel> delete(
+            @PathVariable @Valid @Pattern(regexp = NAME_PATTERN) final String certificateName,
+            @RequestAttribute(name = ApiConstants.REQUEST_BASE_URI) final URI baseUri) {
+        return super.delete(certificateName, baseUri);
+    }
+
+    @Override
+    @GetMapping(value = "/deletedcertificates/{certificateName}",
+            params = API_VERSION_7_3,
+            produces = APPLICATION_JSON_VALUE)
+    public ResponseEntity<DeletedKeyVaultCertificateModel> getDeletedCertificate(
+            @PathVariable @Valid @Pattern(regexp = NAME_PATTERN) final String certificateName,
+            @RequestAttribute(name = ApiConstants.REQUEST_BASE_URI) final URI baseUri) {
+        return super.getDeletedCertificate(certificateName, baseUri);
+    }
+
+    @Override
+    @PostMapping(value = "/deletedcertificates/{certificateName}/recover",
+            params = API_VERSION_7_3,
+            produces = APPLICATION_JSON_VALUE)
+    public ResponseEntity<KeyVaultCertificateModel> recoverDeletedCertificate(
+            @PathVariable @Valid @Pattern(regexp = NAME_PATTERN) final String certificateName,
+            @RequestAttribute(name = ApiConstants.REQUEST_BASE_URI) final URI baseUri) {
+        return super.recoverDeletedCertificate(certificateName, baseUri);
+    }
+
+    @Override
+    @DeleteMapping(value = "/deletedcertificates/{certificateName}",
+            params = API_VERSION_7_3,
+            produces = APPLICATION_JSON_VALUE)
+    public ResponseEntity<Void> purgeDeleted(
+            @PathVariable @Valid @Pattern(regexp = NAME_PATTERN) final String certificateName,
+            @RequestAttribute(name = ApiConstants.REQUEST_BASE_URI) final URI baseUri) {
+        return super.purgeDeleted(certificateName, baseUri);
+    }
+
+    @Override
     @GetMapping(value = "/certificates/{certificateName}/versions",
             params = API_VERSION_7_3,
             produces = APPLICATION_JSON_VALUE)
@@ -129,6 +179,18 @@ public class CertificateController extends CommonCertificateController {
             @RequestParam(name = SKIP_TOKEN_PARAM, required = false, defaultValue = SKIP_ZERO) final int skipToken,
             @RequestParam(name = INCLUDE_PENDING_PARAM, required = false, defaultValue = TRUE) final boolean includePending) {
         return super.listCertificates(baseUri, maxResults, skipToken, includePending);
+    }
+
+    @Override
+    @GetMapping(value = "/deletedcertificates",
+            params = API_VERSION_7_3,
+            produces = APPLICATION_JSON_VALUE)
+    public ResponseEntity<KeyVaultItemListModel<DeletedKeyVaultCertificateItemModel>> listDeletedCertificates(
+            @RequestAttribute(name = ApiConstants.REQUEST_BASE_URI) final URI baseUri,
+            @RequestParam(name = MAX_RESULTS_PARAM, required = false, defaultValue = DEFAULT_MAX) final int maxResults,
+            @RequestParam(name = SKIP_TOKEN_PARAM, required = false, defaultValue = SKIP_ZERO) final int skipToken,
+            @RequestParam(name = INCLUDE_PENDING_PARAM, required = false, defaultValue = TRUE) final boolean includePending) {
+        return super.listDeletedCertificates(baseUri, maxResults, skipToken, includePending);
     }
 
     @Override

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/controller/v7_3/KeyController.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/controller/v7_3/KeyController.java
@@ -6,6 +6,8 @@ import com.github.nagyesta.lowkeyvault.mapper.v7_2.key.KeyEntityToV72KeyVersionI
 import com.github.nagyesta.lowkeyvault.mapper.v7_2.key.KeyEntityToV72ModelConverter;
 import com.github.nagyesta.lowkeyvault.model.common.ApiConstants;
 import com.github.nagyesta.lowkeyvault.model.common.KeyVaultItemListModel;
+import com.github.nagyesta.lowkeyvault.model.v7_2.key.DeletedKeyVaultKeyItemModel;
+import com.github.nagyesta.lowkeyvault.model.v7_2.key.DeletedKeyVaultKeyModel;
 import com.github.nagyesta.lowkeyvault.model.v7_2.key.KeyVaultKeyItemModel;
 import com.github.nagyesta.lowkeyvault.model.v7_2.key.KeyVaultKeyModel;
 import com.github.nagyesta.lowkeyvault.model.v7_2.key.request.CreateKeyRequest;
@@ -106,7 +108,7 @@ public class KeyController extends CommonKeyController {
     @GetMapping(value = "/deletedkeys",
             params = API_VERSION_7_3,
             produces = APPLICATION_JSON_VALUE)
-    public ResponseEntity<KeyVaultItemListModel<KeyVaultKeyItemModel>> listDeletedKeys(
+    public ResponseEntity<KeyVaultItemListModel<DeletedKeyVaultKeyItemModel>> listDeletedKeys(
             @RequestAttribute(name = ApiConstants.REQUEST_BASE_URI) final URI baseUri,
             @RequestParam(name = MAX_RESULTS_PARAM, required = false, defaultValue = DEFAULT_MAX) final int maxResults,
             @RequestParam(name = SKIP_TOKEN_PARAM, required = false, defaultValue = SKIP_ZERO) final int skipToken) {
@@ -165,7 +167,7 @@ public class KeyController extends CommonKeyController {
     @GetMapping(value = "/deletedkeys/{keyName}",
             params = API_VERSION_7_3,
             produces = APPLICATION_JSON_VALUE)
-    public ResponseEntity<KeyVaultKeyModel> getDeletedKey(
+    public ResponseEntity<DeletedKeyVaultKeyModel> getDeletedKey(
             @PathVariable @Valid @Pattern(regexp = NAME_PATTERN) final String keyName,
             @RequestAttribute(name = ApiConstants.REQUEST_BASE_URI) final URI baseUri) {
         return super.getDeletedKey(keyName, baseUri);

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/controller/v7_3/SecretController.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/controller/v7_3/SecretController.java
@@ -6,6 +6,8 @@ import com.github.nagyesta.lowkeyvault.mapper.v7_2.secret.SecretEntityToV72Secre
 import com.github.nagyesta.lowkeyvault.mapper.v7_2.secret.SecretEntityToV72SecretVersionItemModelConverter;
 import com.github.nagyesta.lowkeyvault.model.common.ApiConstants;
 import com.github.nagyesta.lowkeyvault.model.common.KeyVaultItemListModel;
+import com.github.nagyesta.lowkeyvault.model.v7_2.secret.DeletedKeyVaultSecretItemModel;
+import com.github.nagyesta.lowkeyvault.model.v7_2.secret.DeletedKeyVaultSecretModel;
 import com.github.nagyesta.lowkeyvault.model.v7_2.secret.KeyVaultSecretItemModel;
 import com.github.nagyesta.lowkeyvault.model.v7_2.secret.KeyVaultSecretModel;
 import com.github.nagyesta.lowkeyvault.model.v7_2.secret.request.CreateSecretRequest;
@@ -48,9 +50,10 @@ public class SecretController extends CommonSecretController {
             params = API_VERSION_7_3,
             consumes = APPLICATION_JSON_VALUE,
             produces = APPLICATION_JSON_VALUE)
-    public ResponseEntity<KeyVaultSecretModel> create(@PathVariable @Valid @Pattern(regexp = NAME_PATTERN) final String secretName,
-                                                      @RequestAttribute(name = ApiConstants.REQUEST_BASE_URI) final URI baseUri,
-                                                      @Valid @RequestBody final CreateSecretRequest request) {
+    public ResponseEntity<KeyVaultSecretModel> create(
+            @PathVariable @Valid @Pattern(regexp = NAME_PATTERN) final String secretName,
+            @RequestAttribute(name = ApiConstants.REQUEST_BASE_URI) final URI baseUri,
+            @Valid @RequestBody final CreateSecretRequest request) {
         return super.create(secretName, baseUri, request);
     }
 
@@ -58,8 +61,9 @@ public class SecretController extends CommonSecretController {
     @DeleteMapping(value = "/secrets/{secretName}",
             params = API_VERSION_7_3,
             produces = APPLICATION_JSON_VALUE)
-    public ResponseEntity<KeyVaultSecretModel> delete(@PathVariable @Valid @Pattern(regexp = NAME_PATTERN) final String secretName,
-                                                      @RequestAttribute(name = ApiConstants.REQUEST_BASE_URI) final URI baseUri) {
+    public ResponseEntity<DeletedKeyVaultSecretModel> delete(
+            @PathVariable @Valid @Pattern(regexp = NAME_PATTERN) final String secretName,
+            @RequestAttribute(name = ApiConstants.REQUEST_BASE_URI) final URI baseUri) {
         return super.delete(secretName, baseUri);
     }
 
@@ -90,7 +94,7 @@ public class SecretController extends CommonSecretController {
     @GetMapping(value = "/deletedsecrets",
             params = API_VERSION_7_3,
             produces = APPLICATION_JSON_VALUE)
-    public ResponseEntity<KeyVaultItemListModel<KeyVaultSecretItemModel>> listDeletedSecrets(
+    public ResponseEntity<KeyVaultItemListModel<DeletedKeyVaultSecretItemModel>> listDeletedSecrets(
             @RequestAttribute(name = ApiConstants.REQUEST_BASE_URI) final URI baseUri,
             @RequestParam(name = MAX_RESULTS_PARAM, required = false, defaultValue = DEFAULT_MAX) final int maxResults,
             @RequestParam(name = SKIP_TOKEN_PARAM, required = false, defaultValue = SKIP_ZERO) final int skipToken) {

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/model/v7_3/certificate/CertificatePropertiesModel.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/model/v7_3/certificate/CertificatePropertiesModel.java
@@ -4,4 +4,8 @@ import com.github.nagyesta.lowkeyvault.model.v7_2.BasePropertiesModel;
 
 public final class CertificatePropertiesModel extends BasePropertiesModel {
 
+    public CertificatePropertiesModel() {
+        this.setRecoverableDays(null);
+        this.setRecoveryLevel(null);
+    }
 }

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/certificate/impl/CertificateVaultFakeImpl.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/certificate/impl/CertificateVaultFakeImpl.java
@@ -6,6 +6,8 @@ import com.github.nagyesta.lowkeyvault.service.certificate.ReadOnlyKeyVaultCerti
 import com.github.nagyesta.lowkeyvault.service.certificate.id.CertificateEntityId;
 import com.github.nagyesta.lowkeyvault.service.certificate.id.VersionedCertificateEntityId;
 import com.github.nagyesta.lowkeyvault.service.common.impl.BaseVaultFakeImpl;
+import com.github.nagyesta.lowkeyvault.service.key.id.KeyEntityId;
+import com.github.nagyesta.lowkeyvault.service.secret.id.SecretEntityId;
 import com.github.nagyesta.lowkeyvault.service.vault.VaultFake;
 import lombok.NonNull;
 
@@ -38,5 +40,34 @@ public class CertificateVaultFakeImpl
         final KeyVaultCertificateEntity entity = new KeyVaultCertificateEntity(
                 name, input, vaultFake());
         return addVersion(entity.getId(), entity);
+    }
+
+    @Override
+    public void delete(@NonNull final CertificateEntityId entityId) {
+        super.delete(entityId);
+        vaultFake().keyVaultFake().delete(toKeyEntityId(entityId));
+        vaultFake().secretVaultFake().delete(toSecretEntityId(entityId));
+    }
+
+    @Override
+    public void recover(@NonNull final CertificateEntityId entityId) {
+        super.recover(entityId);
+        vaultFake().keyVaultFake().recover(toKeyEntityId(entityId));
+        vaultFake().secretVaultFake().recover(toSecretEntityId(entityId));
+    }
+
+    @Override
+    public void purge(@NonNull final CertificateEntityId entityId) {
+        super.purge(entityId);
+        vaultFake().keyVaultFake().purge(toKeyEntityId(entityId));
+        vaultFake().secretVaultFake().purge(toSecretEntityId(entityId));
+    }
+
+    private KeyEntityId toKeyEntityId(final CertificateEntityId entityId) {
+        return new KeyEntityId(entityId.vault(), entityId.id());
+    }
+
+    private SecretEntityId toSecretEntityId(final CertificateEntityId entityId) {
+        return new SecretEntityId(entityId.vault(), entityId.id());
     }
 }

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/controller/v7_2/KeyControllerTest.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/controller/v7_2/KeyControllerTest.java
@@ -506,7 +506,7 @@ class KeyControllerTest {
                 .thenReturn(DELETED_RESPONSE);
 
         //when
-        final ResponseEntity<KeyVaultKeyModel> actual = underTest.getDeletedKey(KEY_NAME_1, HTTPS_LOCALHOST_8443);
+        final ResponseEntity<DeletedKeyVaultKeyModel> actual = underTest.getDeletedKey(KEY_NAME_1, HTTPS_LOCALHOST_8443);
 
         //then
         Assertions.assertNotNull(actual);
@@ -676,7 +676,7 @@ class KeyControllerTest {
                 .thenReturn(keyItemModel);
 
         //when
-        final ResponseEntity<KeyVaultItemListModel<KeyVaultKeyItemModel>> actual =
+        final ResponseEntity<KeyVaultItemListModel<DeletedKeyVaultKeyItemModel>> actual =
                 underTest.listDeletedKeys(HTTPS_LOCALHOST_8443, 1, 0);
 
         //then
@@ -764,7 +764,7 @@ class KeyControllerTest {
                 .thenReturn(keyItemModel);
 
         //when
-        final ResponseEntity<KeyVaultItemListModel<KeyVaultKeyItemModel>> actual =
+        final ResponseEntity<KeyVaultItemListModel<DeletedKeyVaultKeyItemModel>> actual =
                 underTest.listDeletedKeys(HTTPS_LOCALHOST_8443, 1, 0);
 
         //then

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/controller/v7_2/SecretControllerTest.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/controller/v7_2/SecretControllerTest.java
@@ -331,7 +331,7 @@ class SecretControllerTest {
                 .thenReturn(DELETED_RESPONSE);
 
         //when
-        final ResponseEntity<KeyVaultSecretModel> actual = underTest.delete(SECRET_NAME_1, HTTPS_LOCALHOST_8443);
+        final ResponseEntity<DeletedKeyVaultSecretModel> actual = underTest.delete(SECRET_NAME_1, HTTPS_LOCALHOST_8443);
 
         //then
         Assertions.assertNotNull(actual);
@@ -642,7 +642,7 @@ class SecretControllerTest {
                 .thenReturn(secretItemModel);
 
         //when
-        final ResponseEntity<KeyVaultItemListModel<KeyVaultSecretItemModel>> actual =
+        final ResponseEntity<KeyVaultItemListModel<DeletedKeyVaultSecretItemModel>> actual =
                 underTest.listDeletedSecrets(HTTPS_LOCALHOST_8443, 1, 0);
 
         //then
@@ -687,7 +687,7 @@ class SecretControllerTest {
                 .thenReturn(secretItemModel);
 
         //when
-        final ResponseEntity<KeyVaultItemListModel<KeyVaultSecretItemModel>> actual =
+        final ResponseEntity<KeyVaultItemListModel<DeletedKeyVaultSecretItemModel>> actual =
                 underTest.listDeletedSecrets(HTTPS_LOCALHOST_8443, 1, 0);
 
         //then

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/controller/v7_3/KeyControllerTest.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/controller/v7_3/KeyControllerTest.java
@@ -506,7 +506,7 @@ class KeyControllerTest {
                 .thenReturn(DELETED_RESPONSE);
 
         //when
-        final ResponseEntity<KeyVaultKeyModel> actual = underTest.getDeletedKey(KEY_NAME_1, HTTPS_LOCALHOST_8443);
+        final ResponseEntity<DeletedKeyVaultKeyModel> actual = underTest.getDeletedKey(KEY_NAME_1, HTTPS_LOCALHOST_8443);
 
         //then
         Assertions.assertNotNull(actual);
@@ -676,7 +676,7 @@ class KeyControllerTest {
                 .thenReturn(keyItemModel);
 
         //when
-        final ResponseEntity<KeyVaultItemListModel<KeyVaultKeyItemModel>> actual =
+        final ResponseEntity<KeyVaultItemListModel<DeletedKeyVaultKeyItemModel>> actual =
                 underTest.listDeletedKeys(HTTPS_LOCALHOST_8443, 1, 0);
 
         //then
@@ -764,7 +764,7 @@ class KeyControllerTest {
                 .thenReturn(keyItemModel);
 
         //when
-        final ResponseEntity<KeyVaultItemListModel<KeyVaultKeyItemModel>> actual =
+        final ResponseEntity<KeyVaultItemListModel<DeletedKeyVaultKeyItemModel>> actual =
                 underTest.listDeletedKeys(HTTPS_LOCALHOST_8443, 1, 0);
 
         //then

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/controller/v7_3/SecretControllerTest.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/controller/v7_3/SecretControllerTest.java
@@ -331,7 +331,7 @@ class SecretControllerTest {
                 .thenReturn(DELETED_RESPONSE);
 
         //when
-        final ResponseEntity<KeyVaultSecretModel> actual = underTest.delete(SECRET_NAME_1, HTTPS_LOCALHOST_8443);
+        final ResponseEntity<DeletedKeyVaultSecretModel> actual = underTest.delete(SECRET_NAME_1, HTTPS_LOCALHOST_8443);
 
         //then
         Assertions.assertNotNull(actual);
@@ -683,7 +683,7 @@ class SecretControllerTest {
                 .thenReturn(secretItemModel);
 
         //when
-        final ResponseEntity<KeyVaultItemListModel<KeyVaultSecretItemModel>> actual =
+        final ResponseEntity<KeyVaultItemListModel<DeletedKeyVaultSecretItemModel>> actual =
                 underTest.listDeletedSecrets(HTTPS_LOCALHOST_8443, 1, 0);
 
         //then
@@ -728,7 +728,7 @@ class SecretControllerTest {
                 .thenReturn(secretItemModel);
 
         //when
-        final ResponseEntity<KeyVaultItemListModel<KeyVaultSecretItemModel>> actual =
+        final ResponseEntity<KeyVaultItemListModel<DeletedKeyVaultSecretItemModel>> actual =
                 underTest.listDeletedSecrets(HTTPS_LOCALHOST_8443, 1, 0);
 
         //then

--- a/lowkey-vault-docker/src/test/java/com/github/nagyesta/lowkeyvault/context/CommonTestContext.java
+++ b/lowkey-vault-docker/src/test/java/com/github/nagyesta/lowkeyvault/context/CommonTestContext.java
@@ -94,8 +94,8 @@ public abstract class CommonTestContext<E, D, P, C, V extends ServiceVersion> {
         return listedIds;
     }
 
-    public void setListedIds(final List<String> listedKeyNames) {
-        this.listedIds = listedKeyNames;
+    public void setListedIds(final List<String> listedIds) {
+        this.listedIds = listedIds;
     }
 
     public List<String> getDeletedRecoveryIds() {

--- a/lowkey-vault-docker/src/test/java/com/github/nagyesta/lowkeyvault/steps/CertificateStepDefAssertion.java
+++ b/lowkey-vault-docker/src/test/java/com/github/nagyesta/lowkeyvault/steps/CertificateStepDefAssertion.java
@@ -1,6 +1,8 @@
 package com.github.nagyesta.lowkeyvault.steps;
 
+import com.azure.security.keyvault.certificates.CertificateClient;
 import com.azure.security.keyvault.certificates.models.CertificateContentType;
+import com.azure.security.keyvault.certificates.models.DeletedCertificate;
 import com.azure.security.keyvault.keys.models.KeyVaultKey;
 import com.azure.security.keyvault.secrets.models.KeyVaultSecret;
 import com.github.nagyesta.lowkeyvault.KeyGenUtil;
@@ -110,6 +112,12 @@ public class CertificateStepDefAssertion extends CommonAssertions {
         assertEquals(count, ids.size());
     }
 
+    @Then("the deleted list should contain {int} items")
+    public void theDeletedListShouldContainCountItems(final int count) {
+        final List<String> ids = context.getDeletedRecoveryIds();
+        assertEquals(count, ids.size());
+    }
+
     @And("the downloaded certificate policy has {int} months validity")
     public void theDownloadedCertificatePolicyHasMonthsValidity(final int validity) {
         final Integer actual = context.getDownloadedPolicy().getValidityInMonths();
@@ -120,6 +128,14 @@ public class CertificateStepDefAssertion extends CommonAssertions {
     public void theDownloadedCertificatePolicyHasSubjectAsSubject(final String subject) {
         final String actual = context.getDownloadedPolicy().getSubject();
         assertEquals(subject, actual);
+    }
+
+    @And("the deleted certificate policy named {name} is downloaded")
+    public void theDeletedCertificatePolicyNamedMultiImportIsDownloaded(final String name) {
+        final CertificateClient client = context.getClient(context.getCertificateServiceVersion());
+        final DeletedCertificate deletedCertificate = client.getDeletedCertificate(name);
+        context.setLastDeleted(deletedCertificate);
+        assertNotNull(deletedCertificate);
     }
 
     private X509Certificate getX509Certificate(final CertificateContentType contentType, final String value) throws Exception {

--- a/lowkey-vault-docker/src/test/java/com/github/nagyesta/lowkeyvault/steps/CertificatesStepDefs.java
+++ b/lowkey-vault-docker/src/test/java/com/github/nagyesta/lowkeyvault/steps/CertificatesStepDefs.java
@@ -175,4 +175,40 @@ public class CertificatesStepDefs extends CommonAssertions {
                 .stream().collect(Collectors.toList());
         context.setListedIds(actual);
     }
+
+    @And("{int} certificates with {name} prefix are deleted")
+    public void certificatesWithMultiImportPrefixAreDeleted(final int count, final String prefix) {
+        final CertificateClient client = context.getClient(context.getCertificateServiceVersion());
+        IntStream.range(0, count).forEach(i -> {
+            final DeletedCertificate deletedCertificate = client.beginDeleteCertificate(prefix + i)
+                    .waitForCompletion().getValue();
+            context.setLastDeleted(deletedCertificate);
+        });
+    }
+
+    @And("{int} certificates with {name} prefix are purged")
+    public void certificatesWithMultiImportPrefixArePurged(final int count, final String prefix) {
+        final CertificateClient client = context.getClient(context.getCertificateServiceVersion());
+        IntStream.range(0, count).forEach(i -> {
+            client.purgeDeletedCertificate(prefix + i);
+        });
+    }
+
+    @And("{int} certificates with {name} prefix are recovered")
+    public void certificatesWithMultiImportPrefixAreRecovered(final int count, final String prefix) {
+        final CertificateClient client = context.getClient(context.getCertificateServiceVersion());
+        IntStream.range(0, count).forEach(i -> {
+            client.beginRecoverDeletedCertificate(prefix + i).waitForCompletion();
+        });
+    }
+
+    @When("the deleted certificates are listed")
+    public void theDeletedCertificatesAreListed() {
+        final List<String> recoveryIds = context.getClient(context.getCertificateServiceVersion())
+                .listDeletedCertificates()
+                .stream()
+                .map(DeletedCertificate::getRecoveryId)
+                .collect(Collectors.toList());
+        context.setDeletedRecoveryIds(recoveryIds);
+    }
 }

--- a/lowkey-vault-docker/src/test/resources/com/github/nagyesta/lowkeyvault/certificates/DeleteCertificates.feature
+++ b/lowkey-vault-docker/src/test/resources/com/github/nagyesta/lowkeyvault/certificates/DeleteCertificates.feature
@@ -1,0 +1,95 @@
+Feature: Certificate delete/purge/recover
+
+  @Certificate @CertificateImport @CertificateDelete @RSA @CreateVault
+  Scenario Outline: RSA_CERT_DELETE_01 Single versions of multiple RSA certificates imported and deleted then get as deleted
+    Given certificate API version <api> is used
+    And a vault is created with name cert-del-rsa-<index>
+    And a certificate client is created with the vault named cert-del-rsa-<index>
+    And 1 certificates are imported from the resource named <fileName> using - as password
+    When 1 certificates with multi-import- prefix are deleted
+    Then the deleted certificate policy named multi-import-0 is downloaded
+
+    Examples:
+      | api | index | fileName          |
+      | 7.3 | 1     | rsa-localhost.pem |
+
+  @Certificate @CertificateImport @CertificateDelete @EC @CreateVault
+  Scenario Outline: EC_CERT_DELETE_01 Single versions of multiple EC certificates imported and deleted then get as deleted
+    Given certificate API version <api> is used
+    And a vault is created with name cert-del-ec-<index>
+    And a certificate client is created with the vault named cert-del-ec-<index>
+    And 1 certificates are imported from the resource named <fileName> using - as password
+    When 1 certificates with multi-import- prefix are deleted
+    Then the deleted certificate policy named multi-import-0 is downloaded
+
+    Examples:
+      | api | index | fileName               |
+      | 7.3 | 1     | ec521-ec-localhost.pem |
+
+  @Certificate @CertificateImport @CertificateDelete @RSA @CreateVault
+  Scenario Outline: RSA_CERT_PURGE_01 Single versions of multiple RSA certificates imported and deleted then purged
+    Given certificate API version <api> is used
+    And a vault is created with name cert-purge-rsa-<index>
+    And a certificate client is created with the vault named cert-purge-rsa-<index>
+    And 1 certificates are imported from the resource named <fileName> using - as password
+    When 1 certificates with multi-import- prefix are deleted
+    And 1 certificates with multi-import- prefix are purged
+    Then the deleted certificates are listed
+    And the deleted list should contain 0 items
+    And the certificates are listed
+    And the list should contain 0 items
+
+    Examples:
+      | api | index | fileName          |
+      | 7.3 | 1     | rsa-localhost.pem |
+
+  @Certificate @CertificateImport @CertificateDelete @EC @CreateVault
+  Scenario Outline: EC_CERT_PURGE_01 Single versions of multiple EC certificates imported and deleted then purged
+    Given certificate API version <api> is used
+    And a vault is created with name cert-purge-ec-<index>
+    And a certificate client is created with the vault named cert-purge-ec-<index>
+    And 1 certificates are imported from the resource named <fileName> using - as password
+    When 1 certificates with multi-import- prefix are deleted
+    And 1 certificates with multi-import- prefix are purged
+    Then the deleted certificates are listed
+    And the deleted list should contain 0 items
+    And the certificates are listed
+    And the list should contain 0 items
+
+    Examples:
+      | api | index | fileName               |
+      | 7.3 | 1     | ec521-ec-localhost.pem |
+
+  @Certificate @CertificateImport @CertificateDelete @RSA @CreateVault
+  Scenario Outline: RSA_CERT_RECOVER_01 Single versions of multiple RSA certificates imported and deleted then recovered
+    Given certificate API version <api> is used
+    And a vault is created with name cert-recover-rsa-<index>
+    And a certificate client is created with the vault named cert-recover-rsa-<index>
+    And 1 certificates are imported from the resource named <fileName> using - as password
+    When 1 certificates with multi-import- prefix are deleted
+    And 1 certificates with multi-import- prefix are recovered
+    Then the deleted certificates are listed
+    And the deleted list should contain 0 items
+    And the certificates are listed
+    And the list should contain 1 items
+
+    Examples:
+      | api | index | fileName          |
+      | 7.3 | 1     | rsa-localhost.pem |
+
+  @Certificate @CertificateImport @CertificateDelete @EC @CreateVault
+  Scenario Outline: EC_CERT_RECOVER_01 Single versions of multiple EC certificates imported and deleted then recovered
+    Given certificate API version <api> is used
+    And a vault is created with name cert-recover-ec-<index>
+    And a certificate client is created with the vault named cert-recover-ec-<index>
+    And 1 certificates are imported from the resource named <fileName> using - as password
+    When 1 certificates with multi-import- prefix are deleted
+    And 1 certificates with multi-import- prefix are recovered
+    Then the deleted certificates are listed
+    And the deleted list should contain 0 items
+    And the certificates are listed
+    And the list should contain 1 items
+
+    Examples:
+      | api | index | fileName               |
+      | 7.3 | 1     | ec521-ec-localhost.pem |

--- a/lowkey-vault-docker/src/test/resources/com/github/nagyesta/lowkeyvault/certificates/ListDeletedCertificates.feature
+++ b/lowkey-vault-docker/src/test/resources/com/github/nagyesta/lowkeyvault/certificates/ListDeletedCertificates.feature
@@ -1,0 +1,31 @@
+Feature: Certificate list deleted
+
+  @Certificate @CertificateImport @CertificateListDeleted @RSA @CreateVault
+  Scenario Outline: RSA_CERT_LIST_DELETED_01 Single versions of multiple RSA certificates imported and deleted then listed as deleted
+    Given certificate API version <api> is used
+    And a vault is created with name cert-list-deleted-rsa-<index>
+    And a certificate client is created with the vault named cert-list-deleted-rsa-<index>
+    And <count> certificates are imported from the resource named <fileName> using - as password
+    And <count> certificates with multi-import- prefix are deleted
+    When the deleted certificates are listed
+    Then the deleted list should contain <count> items
+
+    Examples:
+      | api | index | fileName          | count |
+      | 7.3 | 1     | rsa-localhost.pem | 1     |
+      | 7.3 | 2     | rsa-localhost.pem | 5     |
+
+  @Certificate @CertificateImport @CertificateListDeleted @EC @CreateVault
+  Scenario Outline: EC_CERT_LIST_DELETED_01 Single versions of multiple EC certificates imported and deleted then listed as deleted
+    Given certificate API version <api> is used
+    And a vault is created with name cert-list-deleted-ec-<index>
+    And a certificate client is created with the vault named cert-list-deleted-ec-<index>
+    And <count> certificates are imported from the resource named <fileName> using - as password
+    And <count> certificates with multi-import- prefix are deleted
+    When the deleted certificates are listed
+    Then the deleted list should contain <count> items
+
+    Examples:
+      | api | index | fileName               | count |
+      | 7.3 | 1     | ec521-ec-localhost.pem | 1     |
+      | 7.3 | 2     | ec521-ec-localhost.pem | 5     |


### PR DESCRIPTION
__Issue:__ #478 <!-- #issue number -->

### Description
<!-- A short summary of changes -->

- Adds new certificate controller endpoint for delete certificate
- Adds new certificate controller endpoint for recover certificate
- Adds new certificate controller endpoint for purge certificate
- Adds new certificate controller endpoint for get deleted certificate
- Adds new certificate controller endpoint for get deleted certificates
- Adds new certificate controller endpoint for pending deleted operation
- Minor refactoring in related code of key/secret controllers
- Changes CertificateVaultFake to forward delete/purge/recover calls to the managed entities
- Adds new tests to cover new CertificateVaultFake features
- Adds new integration tests to cover new CertificateController endpoints
- Adds new end-to-end tests to cover new CertificateController endpoints
- Removes recovery specific information from certificate policy models
- Updates documentation

### Entry point
<!-- Where should the reviewer start in order to properly understand the PR? -->

-

### Checklists

- [x] I have rebased my branch
- [x] My commit message is meaningful
- [x] The commit messages use semantic versioning: ```{major}```, ```{minor}``` or ```{patch}```
- [x] The changes are focusing on the issue at hand
- [x] I have maintained or increased test coverage

### Notes

-
<!-- Any additional remarks you may have. -->
