### PR TITLE
Investigate whether Lowkey Vault could export PKCS12 stores with blank password

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Java version](https://img.shields.io/badge/Java%20version-11-yellow?logo=java)](https://img.shields.io/badge/Java%20version-11-yellow?logo=java)
 [![latest-release](https://img.shields.io/github/v/tag/nagyesta/lowkey-vault?color=blue&logo=git&label=releases&sort=semver)](https://github.com/nagyesta/lowkey-vault/releases)
 [![Maven Central](https://img.shields.io/maven-central/v/com.github.nagyesta.lowkey-vault/lowkey-vault-app?logo=apache-maven)](https://search.maven.org/search?q=com.github.nagyesta.lowkey-vault)
-[![Docker Hub](https://img.shields.io/docker/v/nagyesta/lowkey-vault?label=docker%20hub&logo=docker&sort=semver)](https://hub.docker.com/repository/docker/nagyesta/lowkey-vault)
+[![Docker Hub](https://img.shields.io/docker/v/nagyesta/lowkey-vault?label=docker%20hub&logo=docker&sort=semver)](https://hub.docker.com/r/nagyesta/lowkey-vault)
 [![JavaCI](https://img.shields.io/github/actions/workflow/status/nagyesta/lowkey-vault/gradle.yml?logo=github&branch=main)](https://github.com/nagyesta/lowkey-vault/actions/workflows/gradle.yml)
 
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/5577/badge)](https://bestpractices.coreinfrastructure.org/projects/5577)
@@ -152,7 +152,8 @@ Lowkey Vault is far from supporting all Azure Key Vault features. The list suppo
 - API version supported: ```7.3```
 - Create certificate
     - Self-signed only
-    - Password used for PKCS12 stores: `lowkey-vault`
+    - Using `PKCS12` (`.pfx`) or `PEM` (`.pem`) formats
+    - The downloadable certificate is protected using a blank (`""`) password for `PKCS12` stores
 - Get certificate operation
     - Get pending create operation results
     - Get pending delete operation results
@@ -164,7 +165,8 @@ Lowkey Vault is far from supporting all Azure Key Vault features. The list suppo
 - Get certificate policy
 - Import certificate
     - Self-signed only
-    - The downloadable certificate is protected using `lowkey-vault` as password for PKCS12 stores
+    - Using `PKCS12` (`.pfx`) or `PEM` (`.pem`) formats
+    - The downloadable certificate is protected using a blank (`""`) password for `PKCS12` stores
 - Get deleted certificate
     - Latest version of a single certificate
     - List of all certificate

--- a/lowkey-vault-app/README.md
+++ b/lowkey-vault-app/README.md
@@ -3,7 +3,7 @@
 [![GitHub license](https://img.shields.io/github/license/nagyesta/lowkey-vault?color=informational)](https://raw.githubusercontent.com/nagyesta/lowkey-vault/main/LICENSE)
 [![Java version](https://img.shields.io/badge/Java%20version-11-yellow?logo=java)](https://img.shields.io/badge/Java%20version-11-yellow?logo=java)
 [![latest-release](https://img.shields.io/github/v/tag/nagyesta/lowkey-vault?color=blue&logo=git&label=releases&sort=semver)](https://github.com/nagyesta/lowkey-vault/releases)
-[![Docker Hub](https://img.shields.io/docker/v/nagyesta/lowkey-vault?label=docker%20hub&logo=docker&sort=semver)](https://hub.docker.com/repository/docker/nagyesta/lowkey-vault)
+[![Docker Hub](https://img.shields.io/docker/v/nagyesta/lowkey-vault?label=docker%20hub&logo=docker&sort=semver)](https://hub.docker.com/r/nagyesta/lowkey-vault)
 [![JavaCI](https://img.shields.io/github/actions/workflow/status/nagyesta/lowkey-vault/gradle.yml?logo=github&branch=main)](https://github.com/nagyesta/lowkey-vault/actions/workflows/gradle.yml)
 [![codecov](https://img.shields.io/codecov/c/github/nagyesta/lowkey-vault?label=Coverage&flag=app&token=3ZZ9Q4S5WW)](https://img.shields.io/codecov/c/github/nagyesta/lowkey-vault?label=Coverage&flag=app&token=3ZZ9Q4S5WW)
 [![badge-abort-mission-armed-green](https://raw.githubusercontent.com/nagyesta/abort-mission/wiki_assets/.github/assets/badge-abort-mission-armed-green.svg)](https://github.com/nagyesta/abort-mission)

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/certificate/impl/CertContentType.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/certificate/impl/CertContentType.java
@@ -37,7 +37,7 @@ public enum CertContentType {
      * Certificate in PKCS12 format.
      */
     PKCS12("application/x-pkcs12") {
-        private static final String DEFAULT_PASSWORD = "lowkey-vault";
+        private static final String DEFAULT_PASSWORD = "";
         private static final String KEY_STORE_TYPE_PKCS12 = "PKCS12";
 
         @Override

--- a/lowkey-vault-client/README.md
+++ b/lowkey-vault-client/README.md
@@ -3,7 +3,7 @@
 [![GitHub license](https://img.shields.io/github/license/nagyesta/lowkey-vault?color=informational)](https://raw.githubusercontent.com/nagyesta/lowkey-vault/main/LICENSE)
 [![Java version](https://img.shields.io/badge/Java%20version-11-yellow?logo=java)](https://img.shields.io/badge/Java%20version-11-yellow?logo=java)
 [![latest-release](https://img.shields.io/github/v/tag/nagyesta/lowkey-vault?color=blue&logo=git&label=releases&sort=semver)](https://github.com/nagyesta/lowkey-vault/releases)
-[![Docker Hub](https://img.shields.io/docker/v/nagyesta/lowkey-vault?label=docker%20hub&logo=docker&sort=semver)](https://hub.docker.com/repository/docker/nagyesta/lowkey-vault)
+[![Docker Hub](https://img.shields.io/docker/v/nagyesta/lowkey-vault?label=docker%20hub&logo=docker&sort=semver)](https://hub.docker.com/r/nagyesta/lowkey-vault)
 [![JavaCI](https://img.shields.io/github/actions/workflow/status/nagyesta/lowkey-vault/gradle.yml?logo=github&branch=main)](https://github.com/nagyesta/lowkey-vault/actions/workflows/gradle.yml)
 [![codecov](https://img.shields.io/codecov/c/github/nagyesta/lowkey-vault?label=Coverage&flag=client&token=3ZZ9Q4S5WW)](https://img.shields.io/codecov/c/github/nagyesta/lowkey-vault?label=Coverage&flag=client&token=3ZZ9Q4S5WW)
 [![badge-abort-mission-armed-green](https://raw.githubusercontent.com/nagyesta/abort-mission/wiki_assets/.github/assets/badge-abort-mission-armed-green.svg)](https://github.com/nagyesta/abort-mission)

--- a/lowkey-vault-docker/README.md
+++ b/lowkey-vault-docker/README.md
@@ -3,8 +3,8 @@
 [![GitHub license](https://img.shields.io/github/license/nagyesta/lowkey-vault?color=informational)](https://raw.githubusercontent.com/nagyesta/lowkey-vault/main/LICENSE)
 [![Java version](https://img.shields.io/badge/Java%20version-11-yellow?logo=java)](https://img.shields.io/badge/Java%20version-11-yellow?logo=java)
 [![latest-release](https://img.shields.io/github/v/tag/nagyesta/lowkey-vault?color=blue&logo=git&label=releases&sort=semver)](https://github.com/nagyesta/lowkey-vault/releases)
-[![Docker Hub](https://img.shields.io/docker/v/nagyesta/lowkey-vault?label=docker%20hub&logo=docker&sort=semver)](https://hub.docker.com/repository/docker/nagyesta/lowkey-vault)
-[![Docker Pulls](https://img.shields.io/docker/pulls/nagyesta/lowkey-vault?logo=docker)](https://hub.docker.com/repository/docker/nagyesta/lowkey-vault)
+[![Docker Hub](https://img.shields.io/docker/v/nagyesta/lowkey-vault?label=docker%20hub&logo=docker&sort=semver)](https://hub.docker.com/r/nagyesta/lowkey-vault)
+[![Docker Pulls](https://img.shields.io/docker/pulls/nagyesta/lowkey-vault?logo=docker)](https://hub.docker.com/r/nagyesta/lowkey-vault)
 [![JavaCI](https://img.shields.io/github/actions/workflow/status/nagyesta/lowkey-vault/gradle.yml?logo=github&branch=main)](https://github.com/nagyesta/lowkey-vault/actions/workflows/gradle.yml)
 [![badge-abort-mission-armed-green](https://raw.githubusercontent.com/nagyesta/abort-mission/wiki_assets/.github/assets/badge-abort-mission-armed-green.svg)](https://github.com/nagyesta/abort-mission)
 

--- a/lowkey-vault-docker/src/test/java/com/github/nagyesta/lowkeyvault/steps/CertificateStepDefAssertion.java
+++ b/lowkey-vault-docker/src/test/java/com/github/nagyesta/lowkeyvault/steps/CertificateStepDefAssertion.java
@@ -12,19 +12,20 @@ import com.github.nagyesta.lowkeyvault.context.SecretTestContext;
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.Then;
 import org.apache.commons.codec.binary.Base64;
+import org.bouncycastle.crypto.CryptoException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.Base64Utils;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.security.Key;
-import java.security.KeyStore;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
+import java.security.*;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
+import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.spec.PKCS8EncodedKeySpec;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Enumeration;
@@ -33,7 +34,7 @@ import java.util.Objects;
 
 public class CertificateStepDefAssertion extends CommonAssertions {
 
-    private static final String DEFAULT_PASSWORD = "lowkey-vault";
+    private static final String DEFAULT_PASSWORD = "";
     @SuppressWarnings("SpringJavaAutowiredMembersInspection")
     @Autowired
     private CertificateTestContext context;
@@ -92,17 +93,25 @@ public class CertificateStepDefAssertion extends CommonAssertions {
         final X509Certificate certificate = getX509Certificate(contentType, value);
         if (contentType == CertificateContentType.PEM) {
             final String expected = new String(content, StandardCharsets.UTF_8);
+            //compare PEM content
             assertEquals(expected, value);
+            //Check whether private key and public key are a pair
+            final PrivateKey actualKey = getKeyFromPem(extractKeyByteArray(value), certificate);
+            assertPrivateKeyMatchesPublic(certificate, actualKey);
         } else {
-            final KeyStore keyStore = getKeyStore(content, password);
-            final String alias = findAlias(keyStore);
-            final X509Certificate expectedCertificate = (X509Certificate) keyStore.getCertificate(alias);
-            assertEquals(expectedCertificate, certificate);
-            final Key key = keyStore.getKey(alias, password.toCharArray());
-            final KeyStore expectedKeyStore = getKeyStore(Base64Utils.decodeFromString(value), DEFAULT_PASSWORD);
+            //compare certificates
+            final KeyStore expectedKeyStore = getKeyStore(content, password);
             final String expectedAlias = findAlias(expectedKeyStore);
-            final Key expectedKey = expectedKeyStore.getKey(expectedAlias, DEFAULT_PASSWORD.toCharArray());
-            assertEquals(expectedKey, key);
+            final X509Certificate expectedCertificate = (X509Certificate) expectedKeyStore.getCertificate(expectedAlias);
+            assertEquals(expectedCertificate, certificate);
+            //compare keys
+            final Key expectedKey = expectedKeyStore.getKey(expectedAlias, password.toCharArray());
+            final KeyStore actualKeyStore = getKeyStore(Base64Utils.decodeFromString(value), DEFAULT_PASSWORD);
+            final String actualAlias = findAlias(actualKeyStore);
+            final Key actualKey = actualKeyStore.getKey(actualAlias, DEFAULT_PASSWORD.toCharArray());
+            assertKeyEquals(expectedKey, actualKey);
+            //Check whether private key and public key are a pair
+            assertPrivateKeyMatchesPublic(certificate, (PrivateKey) actualKey);
         }
     }
 
@@ -138,11 +147,82 @@ public class CertificateStepDefAssertion extends CommonAssertions {
         assertNotNull(deletedCertificate);
     }
 
+    private PrivateKey getKeyFromPem(final byte[] content, final X509Certificate certificate) throws CryptoException {
+        try {
+            final KeyFactory kf = KeyFactory.getInstance(certificate.getPublicKey().getAlgorithm(), KeyGenUtil.BOUNCY_CASTLE_PROVIDER);
+            final PKCS8EncodedKeySpec privSpec = new PKCS8EncodedKeySpec(content);
+            return kf.generatePrivate(privSpec);
+        } catch (final Exception e) {
+            throw new CryptoException("Failed to acquire key, sue to exception: " + e.getMessage(), e);
+        }
+    }
+
+    private void assertPrivateKeyMatchesPublic(final X509Certificate certificate, final PrivateKey actualKey) throws CryptoException {
+        final byte[] thumbprint = getThumbprint(certificate);
+        final byte[] testSignature = sign(thumbprint, actualKey, certificate.getSigAlgName());
+        final boolean verify = verify(thumbprint, testSignature, certificate.getPublicKey(), certificate.getSigAlgName());
+        assertTrue("The digest signed with the private key should have been verified using the public key.", verify);
+    }
+
+    private byte[] sign(final byte[] digest, final PrivateKey key, final String sigAlgName) throws CryptoException {
+        try {
+            final Signature signature = Signature.getInstance(sigAlgName);
+            signature.initSign(key);
+            signature.update(digest);
+            return signature.sign();
+        } catch (final Exception e) {
+            throw new CryptoException("Unable to sign digest using algorithm: " + sigAlgName);
+        }
+    }
+
+    private boolean verify(final byte[] digest, final byte[] signature, final PublicKey key, final String sigAlgName) throws CryptoException {
+        try {
+            final Signature verify = Signature.getInstance(sigAlgName);
+            verify.initVerify(key);
+            verify.update(digest);
+            return verify.verify(signature);
+        } catch (final Exception e) {
+            throw new CryptoException("Unable to sign digest using algorithm: " + sigAlgName);
+        }
+    }
+
+    public byte[] getThumbprint(final X509Certificate certificate) throws CryptoException {
+        try {
+            final MessageDigest messageDigest = MessageDigest.getInstance("SHA-1");
+            messageDigest.update(certificate.getEncoded());
+            return messageDigest.digest();
+        } catch (final Exception e) {
+            throw new CryptoException("Failed to calculate thumbprint for certificate: " + certificate.getSubjectDN().getName(), e);
+        }
+    }
+
+    private void assertKeyEquals(final Key expectedKey, final Key actualKey) {
+        if (actualKey instanceof ECPrivateKey) {
+            assertEcKeyEquals((ECPrivateKey) expectedKey, (ECPrivateKey) actualKey);
+        } else if (actualKey instanceof RSAPrivateKey) {
+            assertRsaKeyEquals((RSAPrivateKey) expectedKey, (RSAPrivateKey) actualKey);
+        } else {
+            assertFail("Unknown key type found: expected=" + expectedKey.getClass() + ", actual=" + actualKey.getClass());
+        }
+    }
+
+    private void assertRsaKeyEquals(final RSAPrivateKey expectedKey, final RSAPrivateKey actualKey) {
+        assertArrayEquals(actualKey.getEncoded(), expectedKey.getEncoded());
+    }
+
+    private void assertEcKeyEquals(final ECPrivateKey expectedKey, final ECPrivateKey actualKey) {
+        assertEquals(expectedKey.getAlgorithm(), actualKey.getAlgorithm());
+        assertEquals(expectedKey.getFormat(), actualKey.getFormat());
+        assertEquals(expectedKey.getS(), actualKey.getS());
+        assertEquals(expectedKey.getParams(), actualKey.getParams());
+        assertEquals(expectedKey.getFormat(), actualKey.getFormat());
+    }
+
     private X509Certificate getX509Certificate(final CertificateContentType contentType, final String value) throws Exception {
         final X509Certificate certificate;
         if (contentType == CertificateContentType.PEM) {
-            final byte[] encodedCertificate = extractByteArray(value);
-            final CertificateFactory fact = CertificateFactory.getInstance("X.509", KeyGenUtil.BOUNCY_CASTLE_PROVIDER);
+            final byte[] encodedCertificate = extractCertificateByteArray(value);
+            final CertificateFactory fact = CertificateFactory.getInstance("X.509");
             certificate = (X509Certificate) fact.generateCertificate(new ByteArrayInputStream(encodedCertificate));
         } else {
             final byte[] bytes = Base64Utils.decodeFromString(value);
@@ -161,15 +241,22 @@ public class CertificateStepDefAssertion extends CommonAssertions {
 
     private static KeyStore getKeyStore(final byte[] content, final String password)
             throws KeyStoreException, IOException, NoSuchAlgorithmException, CertificateException {
-        final KeyStore keyStore = KeyStore.getInstance("pkcs12", KeyGenUtil.BOUNCY_CASTLE_PROVIDER);
+        final KeyStore keyStore = KeyStore.getInstance("pkcs12");
         keyStore.load(new ByteArrayInputStream(content), password.toCharArray());
         return keyStore;
     }
 
-    private byte[] extractByteArray(final String certificateContent) {
+    private byte[] extractCertificateByteArray(final String certificateContent) {
         final String withoutNewLines = certificateContent.replaceAll("[\n\r]+", "");
         final String keyOnly = withoutNewLines.replaceAll(".*" + "-----BEGIN CERTIFICATE-----", "")
                 .replaceAll("-----END CERTIFICATE-----" + ".*", "");
+        return Base64.decodeBase64(keyOnly);
+    }
+
+    private byte[] extractKeyByteArray(final String certificateContent) {
+        final String withoutNewLines = certificateContent.replaceAll("[\n\r]+", "");
+        final String keyOnly = withoutNewLines.replaceAll(".*" + "-----BEGIN PRIVATE KEY-----", "")
+                .replaceAll("-----END PRIVATE KEY-----" + ".*", "");
         return Base64.decodeBase64(keyOnly);
     }
 }

--- a/lowkey-vault-docker/src/test/java/com/github/nagyesta/lowkeyvault/steps/CommonAssertions.java
+++ b/lowkey-vault-docker/src/test/java/com/github/nagyesta/lowkeyvault/steps/CommonAssertions.java
@@ -35,6 +35,10 @@ public class CommonAssertions {
         Assert.assertEquals(actual, expected);
     }
 
+    protected void assertArrayEquals(final byte[] expected, final byte[] actual) {
+        Assert.assertEquals(actual, expected);
+    }
+
     protected <K, V> void assertContainsEqualEntries(final Map<K, V> expected, final Map<K, V> actual) {
         assertEquals(expected.size(), actual.size());
         expected.forEach((key, value) -> assertEquals(value, actual.get(key)));

--- a/lowkey-vault-testcontainers/README.md
+++ b/lowkey-vault-testcontainers/README.md
@@ -3,7 +3,7 @@
 [![GitHub license](https://img.shields.io/github/license/nagyesta/lowkey-vault?color=informational)](https://raw.githubusercontent.com/nagyesta/lowkey-vault/main/LICENSE)
 [![Java version](https://img.shields.io/badge/Java%20version-11-yellow?logo=java)](https://img.shields.io/badge/Java%20version-11-yellow?logo=java)
 [![latest-release](https://img.shields.io/github/v/tag/nagyesta/lowkey-vault?color=blue&logo=git&label=releases&sort=semver)](https://github.com/nagyesta/lowkey-vault/releases)
-[![Docker Hub](https://img.shields.io/docker/v/nagyesta/lowkey-vault?label=docker%20hub&logo=docker&sort=semver)](https://hub.docker.com/repository/docker/nagyesta/lowkey-vault)
+[![Docker Hub](https://img.shields.io/docker/v/nagyesta/lowkey-vault?label=docker%20hub&logo=docker&sort=semver)](https://hub.docker.com/r/nagyesta/lowkey-vault)
 [![JavaCI](https://img.shields.io/github/actions/workflow/status/nagyesta/lowkey-vault/gradle.yml?logo=github&branch=main)](https://github.com/nagyesta/lowkey-vault/actions/workflows/gradle.yml)
 [![codecov](https://img.shields.io/codecov/c/github/nagyesta/lowkey-vault?label=Coverage&flag=testcontainers&token=3ZZ9Q4S5WW)](https://img.shields.io/codecov/c/github/nagyesta/lowkey-vault?label=Coverage&flag=testcontainers&token=3ZZ9Q4S5WW)
 [![badge-abort-mission-armed-green](https://raw.githubusercontent.com/nagyesta/abort-mission/wiki_assets/.github/assets/badge-abort-mission-armed-green.svg)](https://github.com/nagyesta/abort-mission)


### PR DESCRIPTION
__Issue:__ #488  <!-- #issue number -->

### Description
<!-- A short summary of changes -->

- Sets default PKCS12 password to blank
- Updates test to use new password
- Replaces BouncyCastle provider usage in PKCS12 test cases to avoid issues caused by blank password
- Updates readme with new password
- Replaces Docker HUB links with one that does not require authentication

### Entry point
<!-- Where should the reviewer start in order to properly understand the PR? -->

-

### Checklists

- [x] I have rebased my branch
- [x] My commit message is meaningful
- [x] The commit messages use semantic versioning: ```{major}```, ```{minor}``` or ```{patch}```
- [x] The changes are focusing on the issue at hand
- [x] I have maintained or increased test coverage

### Notes

-
<!-- Any additional remarks you may have. -->
