### PR TITLE
Certificate API - Lifetime action policy execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,9 +179,7 @@ Lowkey Vault is far from supporting all Azure Key Vault features. The list suppo
 Certificate API features are work in progress, many Lowkey Vault features might 
 not work or are known to be broken, for example but not limited to the following:
 
-- Certificate lifetime policy does not have any effect
 - Import and export ignores certificates
-- Time shift is not supported for certificates
 
 ### Management API
 
@@ -220,5 +218,6 @@ not work or are known to be broken, for example but not limited to the following
 # Limitations
 
 - Some encryption/signature algorithms are not supported. Please refer to the ["Features"](#features) section for the up-to-date list of supported algorithms.
-- Certificate Vault features are not supported at the moment
+- Only self-signed certificates are supported by the certificate API.
+- Time shift cannot renew/recreate deleted certificates. Please consider performing deletions after time shift as a work around.
 - Recovery options cannot be configured for vaults created during start-up

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/controller/VaultManagementController.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/controller/VaultManagementController.java
@@ -286,12 +286,17 @@ public class VaultManagementController extends ErrorHandlingAwareController {
                                     schema = @Schema(implementation = ErrorModel.class)
                             ))},
             parameters = {
-                    @Parameter(name = "seconds", example = ONE, description = "The number of seconds we want to shift.")},
+                    @Parameter(name = "seconds", example = ONE, description = "The number of seconds we want to shift."),
+                    @Parameter(name = "regenerateCertificates", example = FALSE,
+                            description = "Whether we allow regeneration of certificates to let their validity match the new time-frame.")},
             requestBody = @RequestBody(content = @Content(mediaType = MimeTypeUtils.APPLICATION_JSON_VALUE)))
     @PutMapping(value = "/time/all", params = {"seconds"})
-    public ResponseEntity<Void> timeShiftAll(@RequestParam final int seconds) {
-        log.info("Received request to shift time of ALL vaults by {} seconds.", seconds);
-        vaultService.timeShift(seconds);
+    public ResponseEntity<Void> timeShiftAll(
+            @RequestParam final int seconds,
+            @RequestParam(required = false, defaultValue = "false") final boolean regenerateCertificates) {
+        log.info("Received request to shift time of ALL vaults by {} seconds, regenerate certificates: {}.",
+                seconds, regenerateCertificates);
+        vaultService.timeShift(seconds, regenerateCertificates);
         return ResponseEntity.noContent().build();
     }
 
@@ -319,12 +324,17 @@ public class VaultManagementController extends ErrorHandlingAwareController {
                             ))},
             parameters = {
                     @Parameter(name = "seconds", example = ONE, description = "The number of seconds we want to shift."),
-                    @Parameter(name = "baseUri", example = BASE_URI, description = "The base URI of the vault we want to shift.")},
+                    @Parameter(name = "baseUri", example = BASE_URI, description = "The base URI of the vault we want to shift."),
+                    @Parameter(name = "regenerateCertificates", example = FALSE,
+                            description = "Whether we allow regeneration of certificates to let their validity match the new time-frame.")},
             requestBody = @RequestBody(content = @Content(mediaType = MimeTypeUtils.APPLICATION_JSON_VALUE)))
     @PutMapping(value = "/time", params = {"baseUri", "seconds"})
-    public ResponseEntity<Void> timeShiftSingle(@RequestParam final URI baseUri, @RequestParam final int seconds) {
-        log.info("Received request to shift time of vault with uri: {} by {} seconds.", baseUri, seconds);
-        vaultService.findByUriIncludeDeleted(baseUri).timeShift(seconds);
+    public ResponseEntity<Void> timeShiftSingle(
+            @RequestParam final URI baseUri, @RequestParam final int seconds,
+            @RequestParam(required = false, defaultValue = "false") final boolean regenerateCertificates) {
+        log.info("Received request to shift time of vault with uri: {}, by {} seconds, regenerate certificates: {}.",
+                baseUri, seconds, regenerateCertificates);
+        vaultService.findByUriIncludeDeleted(baseUri).timeShift(seconds, regenerateCertificates);
         return ResponseEntity.noContent().build();
     }
 }

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/openapi/Examples.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/openapi/Examples.java
@@ -18,6 +18,10 @@ public final class Examples {
      */
     public static final String ALIASES = "[\"" + ALIAS1 + "\",\"" + ALIAS2 + "\"]";
     /**
+     * The literal false as a String.
+     */
+    public static final String FALSE = "false";
+    /**
      * The literal 1 as a String.
      */
     public static final String ONE = "1";

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/certificate/CertificateVaultFake.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/certificate/CertificateVaultFake.java
@@ -16,4 +16,6 @@ public interface CertificateVaultFake
     LifetimeActionPolicy lifetimeActionPolicy(@NonNull CertificateEntityId certificateEntityId);
 
     void setLifetimeActionPolicy(@NonNull LifetimeActionPolicy lifetimeActionPolicy);
+
+    void regenerateCertificates();
 }

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/certificate/ReadOnlyLifetimeActionPolicy.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/certificate/ReadOnlyLifetimeActionPolicy.java
@@ -5,6 +5,7 @@ import com.github.nagyesta.lowkeyvault.service.certificate.id.CertificateEntityI
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 public interface ReadOnlyLifetimeActionPolicy {
 
@@ -20,5 +21,5 @@ public interface ReadOnlyLifetimeActionPolicy {
 
     void validate(int validityMonths);
 
-    List<OffsetDateTime> missedRenewalDays(OffsetDateTime validityStart, OffsetDateTime expiry);
+    List<OffsetDateTime> missedRenewalDays(OffsetDateTime validityStart, Function<OffsetDateTime, OffsetDateTime> createdToExpiryFunction);
 }

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/certificate/impl/CertificateGenerator.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/certificate/impl/CertificateGenerator.java
@@ -55,7 +55,7 @@ public class CertificateGenerator {
     }
 
     public X509Certificate generateCertificate(
-            @NonNull final CertificateCreationInput input) throws CryptoException {
+            @NonNull final ReadOnlyCertificatePolicy input) throws CryptoException {
         try {
             final ReadOnlyAsymmetricKeyVaultKeyEntity readOnlyKeyVaultKey = vault.keyVaultFake().getEntities()
                     .getEntity(kid, ReadOnlyAsymmetricKeyVaultKeyEntity.class);
@@ -94,7 +94,7 @@ public class CertificateGenerator {
         }
     }
 
-    private X509Certificate generateCertificate(final CertificateCreationInput input, final KeyPair keyPair)
+    private X509Certificate generateCertificate(final ReadOnlyCertificatePolicy input, final KeyPair keyPair)
             throws IOException, OperatorCreationException, CertificateException {
 
         final X509v3CertificateBuilder builder = createCertificateBuilder(input, keyPair);
@@ -130,7 +130,7 @@ public class CertificateGenerator {
     }
 
     private X509v3CertificateBuilder createCertificateBuilder(
-            final CertificateCreationInput input, final KeyPair keyPair) throws IOException {
+            final ReadOnlyCertificatePolicy input, final KeyPair keyPair) throws IOException {
         final X500Name subject = generateSubject(input.getSubject());
         final X509v3CertificateBuilder certificate = new JcaX509v3CertificateBuilder(
                 subject, generateSerial(), input.certNotBefore(), input.certExpiry(), subject, keyPair.getPublic());

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/certificate/impl/KeyVaultCertificateEntity.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/certificate/impl/KeyVaultCertificateEntity.java
@@ -10,8 +10,10 @@ import com.github.nagyesta.lowkeyvault.service.key.id.KeyEntityId;
 import com.github.nagyesta.lowkeyvault.service.key.id.VersionedKeyEntityId;
 import com.github.nagyesta.lowkeyvault.service.secret.id.SecretEntityId;
 import com.github.nagyesta.lowkeyvault.service.secret.id.VersionedSecretEntityId;
+import com.github.nagyesta.lowkeyvault.service.secret.impl.KeyVaultSecretEntity;
 import com.github.nagyesta.lowkeyvault.service.vault.VaultFake;
 import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 import org.springframework.util.Assert;
 
@@ -21,8 +23,11 @@ import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
 import java.util.Optional;
 
+@Slf4j
 public class KeyVaultCertificateEntity
         extends KeyVaultBaseEntity<VersionedCertificateEntityId>
         implements ReadOnlyKeyVaultCertificateEntity {
@@ -31,12 +36,19 @@ public class KeyVaultCertificateEntity
     private final VersionedKeyEntityId kid;
     private final VersionedSecretEntityId sid;
 
-    private final X509Certificate certificate;
-    private final ReadOnlyCertificatePolicy originalCertificateData;
+    private X509Certificate certificate;
+    private ReadOnlyCertificatePolicy originalCertificateData;
     private final String originalCertificateContents;
     private final CertificatePolicy policy;
-    private final PKCS10CertificationRequest csr;
+    private PKCS10CertificationRequest csr;
 
+    /**
+     * Constructor for certificate creation.
+     *
+     * @param name  The name of the certificate entity.
+     * @param input The input parameters.
+     * @param vault The vault we need to use.
+     */
     public KeyVaultCertificateEntity(@NonNull final String name,
                                      @NonNull final CertificateCreationInput input,
                                      @org.springframework.lang.NonNull final VaultFake vault) {
@@ -56,14 +68,26 @@ public class KeyVaultCertificateEntity
         final CertificateGenerator certificateGenerator = new CertificateGenerator(vault, this.kid);
         this.certificate = certificateGenerator.generateCertificate(input);
         this.csr = certificateGenerator.generateCertificateSigningRequest(name, this.certificate);
-        this.sid = generateSecret(input, vault, this.certificate, this.kid);
+        final VersionedSecretEntityId secretEntityId = new VersionedSecretEntityId(vault.baseUri(), input.getName(), this.kid.version());
+        this.sid = generateSecret(this.policy, vault, this.certificate, this.kid, secretEntityId);
         this.setNotBefore(input.getValidityStart());
         this.setExpiry(input.getValidityStart().plusMonths(input.getValidityMonths()));
         this.setEnabled(true);
         this.originalCertificateContents = vault.secretVaultFake().getEntities().getReadOnlyEntity(this.sid).getValue();
         this.originalCertificateData = new CertificatePolicy(input);
+        //update timestamps of certificate as the constructor can run for more than a second
+        this.setCreatedOn(now());
+        this.setUpdatedOn(now());
     }
 
+
+    /**
+     * Constructor for certificate import.
+     *
+     * @param name  The name of the certificate entity.
+     * @param input The input parameters.
+     * @param vault The vault we need to use.
+     */
     public KeyVaultCertificateEntity(@NonNull final String name,
                                      @NonNull final CertificateImportInput input,
                                      @org.springframework.lang.NonNull final VaultFake vault) {
@@ -91,24 +115,65 @@ public class KeyVaultCertificateEntity
         final CertificateGenerator certificateGenerator = new CertificateGenerator(vault, this.kid);
         this.certificate = certificate;
         this.csr = certificateGenerator.generateCertificateSigningRequest(name, this.certificate);
-        this.sid = generateSecret(policy, vault, this.certificate, this.kid);
+        final VersionedSecretEntityId secretEntityId = new VersionedSecretEntityId(vault.baseUri(), input.getName(), this.kid.version());
+        this.sid = generateSecret(this.policy, vault, this.certificate, this.kid, secretEntityId);
         this.setNotBefore(policy.getValidityStart());
         this.setExpiry(policy.getValidityStart().plusMonths(policy.getValidityMonths()));
         this.setEnabled(true);
         this.originalCertificateContents = vault.secretVaultFake().getEntities().getReadOnlyEntity(this.sid).getValue();
         this.originalCertificateData = new CertificatePolicy(originalCertificateData);
+        //update timestamps of certificate as the constructor can run for more than a second
+        this.setCreatedOn(now());
+        this.setUpdatedOn(now());
+    }
+
+    /**
+     * Constructor for certificate renewal.
+     *
+     * @param input The input parameters defining how the certificate should look like.
+     * @param kid   The Id of the key entity version we need to use.
+     * @param id    The Id of the new certificate entity.
+     * @param vault The vault we are using.
+     */
+    public KeyVaultCertificateEntity(@NonNull final ReadOnlyCertificatePolicy input,
+                                     @NonNull final VersionedKeyEntityId kid,
+                                     @NonNull final VersionedCertificateEntityId id,
+                                     @org.springframework.lang.NonNull final VaultFake vault) {
+        super(vault);
+        Assert.state(vault.keyVaultFake().getEntities().containsEntity(kid),
+                "Key must exist to be able to renew certificate using it. " + kid.asUriNoVersion(vault.baseUri()));
+        Assert.state(vault.secretVaultFake().getEntities().containsName(input.getName()),
+                "A version of the Secret must exist to be able to generate a new version using name: " + input.getName());
+        this.policy = new CertificatePolicy(input);
+        this.kid = kid;
+        //use the provided id, it might be different from the key id in case the key is reused.
+        this.id = id;
+        final CertificateGenerator certificateGenerator = new CertificateGenerator(vault, this.kid);
+        this.certificate = certificateGenerator.generateCertificate(input);
+        this.csr = certificateGenerator.generateCertificateSigningRequest(input.getName(), this.certificate);
+        final VersionedSecretEntityId secretEntityId = new VersionedSecretEntityId(vault.baseUri(), input.getName(), id.version());
+        this.sid = generateSecret(this.policy, vault, this.certificate, this.kid, secretEntityId);
+        this.setNotBefore(input.getValidityStart());
+        final OffsetDateTime expiry = input.getValidityStart().plusMonths(input.getValidityMonths());
+        this.setExpiry(expiry);
+        this.setEnabled(true);
+        this.originalCertificateContents = vault.secretVaultFake().getEntities().getReadOnlyEntity(this.sid).getValue();
+        this.originalCertificateData = new CertificatePolicy(input);
+        //update timestamps of certificate
+        this.setCreatedOn(input.getValidityStart());
+        this.setUpdatedOn(input.getValidityStart());
     }
 
     private VersionedSecretEntityId generateSecret(final ReadOnlyCertificatePolicy input,
                                                    final VaultFake vault,
                                                    final Certificate certificate,
-                                                   final VersionedKeyEntityId kid) {
+                                                   final VersionedKeyEntityId kid,
+                                                   final VersionedSecretEntityId sid) {
         final KeyPair key = vault.keyVaultFake().getEntities().getEntity(kid, ReadOnlyAsymmetricKeyVaultKeyEntity.class).getKey();
         final String value = input.getContentType().asBase64CertificatePackage(certificate, key);
-        final OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
-        final OffsetDateTime expiry = now.plusMonths(input.getValidityMonths());
-        final VersionedSecretEntityId secretId = new VersionedSecretEntityId(vault.baseUri(), input.getName(), kid.version());
-        return vault.secretVaultFake().createSecretVersionForCertificate(secretId, value, input.getContentType(), now, expiry);
+        final OffsetDateTime start = input.getValidityStart();
+        final OffsetDateTime expiry = start.plusMonths(input.getValidityMonths());
+        return vault.secretVaultFake().createSecretVersionForCertificate(sid, value, input.getContentType(), start, expiry);
     }
 
     private VersionedKeyEntityId generateKeyPair(final ReadOnlyCertificatePolicy input, final VaultFake vault) {
@@ -193,5 +258,48 @@ public class KeyVaultCertificateEntity
         } catch (final Exception e) {
             throw new CryptoException("Failed to obtain encoded certificate signing request: " + getId().toString(), e);
         }
+    }
+
+    @Override
+    public void timeShift(final int offsetSeconds) {
+        super.timeShift(offsetSeconds);
+        //reset expiry as it is measured in months while timeShift is using seconds
+        //it is better to stay consistent with the behavior of the certificates
+        this.setExpiry(this.getNotBefore().orElse(this.getCreated()).plusMonths(this.policy.getValidityMonths()));
+    }
+
+    public void regenerateCertificate(final VaultFake vault) {
+        if (this.getDeletedDate().isPresent()) {
+            log.warn("Deleted certificate is regeneration is skipped for: {}", id);
+        } else if (validityStartDateNoLongerAccurate()) {
+            log.debug("Regenerating certificate: {}", id);
+            final CertificatePolicy updated = new CertificatePolicy(originalCertificateData);
+            updated.setValidityStart(getCreated());
+            regenerateCertificateData(vault, updated);
+            updateSecretValueWithNewCertificate(vault, updated);
+        } else {
+            log.debug("Validity start date is still accurate certificate won't be changed: {}", id);
+        }
+    }
+
+    private void updateSecretValueWithNewCertificate(final VaultFake vault, final CertificatePolicy updated) {
+        final ReadOnlyAsymmetricKeyVaultKeyEntity key = vault.keyVaultFake().getEntities()
+                .getEntity(kid, ReadOnlyAsymmetricKeyVaultKeyEntity.class);
+        final KeyVaultSecretEntity secret = vault.secretVaultFake().getEntities().getEntity(this.sid, KeyVaultSecretEntity.class);
+        secret.setValue(updated.getContentType().asBase64CertificatePackage(certificate, key.getKey()));
+    }
+
+    private void regenerateCertificateData(final VaultFake vaultFake, final CertificatePolicy updated) {
+        final CertificateGenerator certificateGenerator = new CertificateGenerator(vaultFake, this.kid);
+        this.certificate = certificateGenerator.generateCertificate(updated);
+        this.csr = certificateGenerator.generateCertificateSigningRequest(this.id.id(), this.certificate);
+        this.originalCertificateData = updated;
+    }
+
+    private boolean validityStartDateNoLongerAccurate() {
+        final OffsetDateTime validityStart = this.getNotBefore().orElse(this.getCreated());
+        final Date desiredStartOfValidity = Date.from(validityStart.truncatedTo(ChronoUnit.DAYS).toInstant());
+        final Date existingStartOfValidity = certificate.getNotBefore();
+        return !desiredStartOfValidity.equals(existingStartOfValidity);
     }
 }

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/common/impl/BaseVaultFakeImpl.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/common/impl/BaseVaultFakeImpl.java
@@ -134,6 +134,10 @@ public abstract class BaseVaultFakeImpl<K extends EntityId, V extends K, RE exte
         return entities;
     }
 
+    protected VersionedEntityMultiMap<K, V, RE, ME> getDeletedEntitiesInternal() {
+        return deletedEntities;
+    }
+
     protected VaultFake vaultFake() {
         return vaultFake;
     }

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/key/impl/KeyRotationPolicy.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/key/impl/KeyRotationPolicy.java
@@ -3,6 +3,7 @@ package com.github.nagyesta.lowkeyvault.service.key.impl;
 import com.github.nagyesta.lowkeyvault.model.v7_3.key.constants.LifetimeActionType;
 import com.github.nagyesta.lowkeyvault.service.common.impl.BaseLifetimePolicy;
 import com.github.nagyesta.lowkeyvault.service.key.LifetimeAction;
+import com.github.nagyesta.lowkeyvault.service.key.LifetimeActionTrigger;
 import com.github.nagyesta.lowkeyvault.service.key.RotationPolicy;
 import com.github.nagyesta.lowkeyvault.service.key.constants.LifetimeActionTriggerType;
 import com.github.nagyesta.lowkeyvault.service.key.id.KeyEntityId;
@@ -39,9 +40,9 @@ public class KeyRotationPolicy extends BaseLifetimePolicy<KeyEntityId> implement
     @Override
     public List<OffsetDateTime> missedRotations(@NonNull final OffsetDateTime keyCreation) {
         Assert.isTrue(isAutoRotate(), "Cannot have missed rotations without a \"rotate\" lifetime action.");
-        final long rotateAfterDays = lifetimeActions.get(LifetimeActionType.ROTATE).getTrigger().rotateAfterDays(expiryTime);
-        final OffsetDateTime startPoint = findTriggerTimeOffset(keyCreation, rotateAfterDays);
-        return collectMissedTriggerDays(rotateAfterDays, startPoint);
+        final LifetimeActionTrigger trigger = lifetimeActions.get(LifetimeActionType.ROTATE).getTrigger();
+        final OffsetDateTime startPoint = findTriggerTimeOffset(keyCreation, s -> trigger.rotateAfterDays(expiryTime));
+        return collectMissedTriggerDays(s -> trigger.rotateAfterDays(expiryTime), startPoint);
     }
 
     @Override

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/secret/impl/KeyVaultSecretEntity.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/secret/impl/KeyVaultSecretEntity.java
@@ -10,7 +10,7 @@ import org.springframework.util.Assert;
 
 public class KeyVaultSecretEntity extends KeyVaultBaseEntity<VersionedSecretEntityId> implements ReadOnlyKeyVaultSecretEntity {
 
-    private final String value;
+    private String value;
     private final String contentType;
     private final VersionedSecretEntityId id;
 
@@ -28,6 +28,10 @@ public class KeyVaultSecretEntity extends KeyVaultBaseEntity<VersionedSecretEnti
     @Override
     public String getValue() {
         return value;
+    }
+
+    public void setValue(final String value) {
+        this.value = value;
     }
 
     @Override

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/secret/impl/SecretVaultFakeImpl.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/secret/impl/SecretVaultFakeImpl.java
@@ -52,6 +52,9 @@ public class SecretVaultFakeImpl
         setExpiry(secretEntityId, notBefore, expiry);
         setManaged(secretEntityId, true);
         setEnabled(secretEntityId, true);
+        final KeyVaultSecretEntity secretEntity = getEntities().getEntity(secretEntityId, KeyVaultSecretEntity.class);
+        secretEntity.setCreatedOn(notBefore);
+        secretEntity.setUpdatedOn(notBefore);
         return secretEntityId;
     }
 }

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/vault/VaultFake.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/vault/VaultFake.java
@@ -42,5 +42,5 @@ public interface VaultFake {
 
     void recover();
 
-    void timeShift(int offsetSeconds);
+    void timeShift(int offsetSeconds, boolean regenerateCertificates);
 }

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/vault/VaultService.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/vault/VaultService.java
@@ -26,7 +26,7 @@ public interface VaultService {
 
     boolean purge(URI uri);
 
-    void timeShift(int offsetSeconds);
+    void timeShift(int offsetSeconds, boolean regenerateCertificates);
 
     VaultFake updateAlias(URI baseUri, URI add, URI remove);
 }

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/vault/impl/VaultFakeImpl.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/vault/impl/VaultFakeImpl.java
@@ -10,6 +10,7 @@ import com.github.nagyesta.lowkeyvault.service.secret.impl.SecretVaultFakeImpl;
 import com.github.nagyesta.lowkeyvault.service.vault.VaultFake;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.util.Assert;
 
 import java.net.URI;
@@ -18,6 +19,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
+@Slf4j
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, doNotUseGetters = true)
 public class VaultFakeImpl implements VaultFake {
 
@@ -140,7 +142,7 @@ public class VaultFakeImpl implements VaultFake {
     }
 
     @Override
-    public void timeShift(final int offsetSeconds) {
+    public void timeShift(final int offsetSeconds, final boolean regenerateCertificates) {
         Assert.isTrue(offsetSeconds > 0, "Offset must be positive.");
         createdOn = createdOn.minusSeconds(offsetSeconds);
         deletedOn = Optional.ofNullable(deletedOn)
@@ -148,5 +150,10 @@ public class VaultFakeImpl implements VaultFake {
                 .orElse(null);
         keyVaultFake().timeShift(offsetSeconds);
         secretVaultFake().timeShift(offsetSeconds);
+        certificateVaultFake().timeShift(offsetSeconds);
+        if (regenerateCertificates) {
+            log.info("Regenerating certificates of vault: {}", baseUri());
+            certificateVaultFake().regenerateCertificates();
+        }
     }
 }

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/vault/impl/VaultServiceImpl.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/vault/impl/VaultServiceImpl.java
@@ -106,10 +106,10 @@ public class VaultServiceImpl implements VaultService {
     }
 
     @Override
-    public void timeShift(final int offsetSeconds) {
+    public void timeShift(final int offsetSeconds, final boolean regenerateCertificates) {
         Assert.isTrue(offsetSeconds > 0, "Offset must be positive.");
         log.info("Performing time shift with {} seconds for all vaults.", offsetSeconds);
-        vaultFakes.forEach(vaultFake -> vaultFake.timeShift(offsetSeconds));
+        vaultFakes.forEach(vaultFake -> vaultFake.timeShift(offsetSeconds, regenerateCertificates));
         purgeExpired();
     }
 

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/controller/VaultManagementControllerTest.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/controller/VaultManagementControllerTest.java
@@ -231,11 +231,11 @@ class VaultManagementControllerTest {
             //given
 
             //when
-            final ResponseEntity<Void> actual = underTest.timeShiftAll(NUMBER_OF_SECONDS_IN_10_MINUTES);
+            final ResponseEntity<Void> actual = underTest.timeShiftAll(NUMBER_OF_SECONDS_IN_10_MINUTES, false);
 
             //then
             Assertions.assertEquals(HttpStatus.NO_CONTENT, actual.getStatusCode());
-            verify(vaultService).timeShift(eq(NUMBER_OF_SECONDS_IN_10_MINUTES));
+            verify(vaultService).timeShift(eq(NUMBER_OF_SECONDS_IN_10_MINUTES), eq(false));
             verifyNoMoreInteractions(vaultService);
         }
 
@@ -246,7 +246,8 @@ class VaultManagementControllerTest {
             when(vaultService.findByUriIncludeDeleted(eq(HTTPS_DEFAULT_LOWKEY_VAULT))).thenReturn(vaultFakeActive);
 
             //when
-            final ResponseEntity<Void> actual = underTest.timeShiftSingle(HTTPS_DEFAULT_LOWKEY_VAULT, NUMBER_OF_SECONDS_IN_10_MINUTES);
+            final ResponseEntity<Void> actual = underTest
+                    .timeShiftSingle(HTTPS_DEFAULT_LOWKEY_VAULT, NUMBER_OF_SECONDS_IN_10_MINUTES, true);
 
             //then
             Assertions.assertEquals(HttpStatus.NO_CONTENT, actual.getStatusCode());

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/service/secret/impl/SecretVaultFakeImplTest.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/service/secret/impl/SecretVaultFakeImplTest.java
@@ -197,5 +197,8 @@ class SecretVaultFakeImplTest {
         Assertions.assertEquals(expiry, entity.getExpiry().orElse(null));
         Assertions.assertTrue(entity.isEnabled());
         Assertions.assertTrue(entity.isManaged());
+        //created and updated must be set to the same value as not before in case of new certificate backing secrets
+        Assertions.assertEquals(notBefore, entity.getCreated());
+        Assertions.assertEquals(notBefore, entity.getUpdated());
     }
 }

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/service/vault/impl/VaultFakeImplIntegrationTest.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/service/vault/impl/VaultFakeImplIntegrationTest.java
@@ -1,0 +1,200 @@
+package com.github.nagyesta.lowkeyvault.service.vault.impl;
+
+import com.github.nagyesta.lowkeyvault.model.v7_2.common.constants.RecoveryLevel;
+import com.github.nagyesta.lowkeyvault.model.v7_2.key.constants.KeyCurveName;
+import com.github.nagyesta.lowkeyvault.model.v7_2.key.constants.KeyType;
+import com.github.nagyesta.lowkeyvault.service.certificate.CertificateLifetimeActionTrigger;
+import com.github.nagyesta.lowkeyvault.service.certificate.CertificateVaultFake;
+import com.github.nagyesta.lowkeyvault.service.certificate.ReadOnlyKeyVaultCertificateEntity;
+import com.github.nagyesta.lowkeyvault.service.certificate.id.VersionedCertificateEntityId;
+import com.github.nagyesta.lowkeyvault.service.certificate.impl.CertContentType;
+import com.github.nagyesta.lowkeyvault.service.certificate.impl.CertificateCreationInput;
+import com.github.nagyesta.lowkeyvault.service.certificate.impl.CertificateLifetimeActionPolicy;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Deque;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.github.nagyesta.lowkeyvault.TestConstantsCertificates.CERT_NAME_1;
+import static com.github.nagyesta.lowkeyvault.TestConstantsUri.HTTPS_LOCALHOST;
+import static com.github.nagyesta.lowkeyvault.service.certificate.CertificateLifetimeActionActivity.AUTO_RENEW;
+import static com.github.nagyesta.lowkeyvault.service.certificate.CertificateLifetimeActionTriggerType.DAYS_BEFORE_EXPIRY;
+import static com.github.nagyesta.lowkeyvault.service.certificate.impl.CertificateCreationInput.DEFAULT_VALIDITY_MONTHS;
+import static java.time.temporal.ChronoUnit.DAYS;
+import static java.time.temporal.ChronoUnit.MONTHS;
+
+class VaultFakeImplIntegrationTest {
+
+    private static final int INT_800 = 800;
+    private static final int SECONDS_IN_1_DAY = 24 * 3600;
+    private static final int SECONDS_IN_800_DAYS = INT_800 * SECONDS_IN_1_DAY;
+    public static final int EXPECTED_VERSIONS_AFTER_RENEWAL = 3;
+
+    @Test
+    void testTimeShiftShouldCreateNewVersionsWhenAutoRotateIsTriggeredWithActiveCertificates() {
+        //given
+        final VaultFakeImpl underTest = new VaultFakeImpl(HTTPS_LOCALHOST);
+        final CertificateVaultFake certificateVaultFake = underTest.certificateVaultFake();
+        final OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+        final OffsetDateTime approxNow = now.plusMinutes(1);
+        final VersionedCertificateEntityId originalCertId = certificateVaultFake
+                .createCertificateVersion(CERT_NAME_1, CertificateCreationInput.builder()
+                        .contentType(CertContentType.PEM)
+                        .name(CERT_NAME_1)
+                        .keyType(KeyType.EC)
+                        .validityStart(approxNow)
+                        .validityMonths(DEFAULT_VALIDITY_MONTHS)
+                        .keyCurveName(KeyCurveName.P_521)
+                        .subject("CN=localhost")
+                        .build());
+        final int triggerThresholdDays = 1;
+        certificateVaultFake.setLifetimeActionPolicy(new CertificateLifetimeActionPolicy(
+                originalCertId, Map.of(AUTO_RENEW, new CertificateLifetimeActionTrigger(DAYS_BEFORE_EXPIRY, triggerThresholdDays))
+        ));
+
+        //when
+        underTest.timeShift(SECONDS_IN_800_DAYS, true);
+
+        //then
+        final Deque<String> versions = underTest.certificateVaultFake().getEntities().getVersions(originalCertId);
+        final List<ReadOnlyKeyVaultCertificateEntity> entities = versions.stream()
+                .map(v -> new VersionedCertificateEntityId(originalCertId.vault(), originalCertId.id(), v))
+                .map(certificateVaultFake.getEntities()::getReadOnlyEntity)
+                .collect(Collectors.toList());
+        Assertions.assertEquals(EXPECTED_VERSIONS_AFTER_RENEWAL, entities.size());
+        final ReadOnlyKeyVaultCertificateEntity recreatedOriginal = entities.get(0);
+        final ReadOnlyKeyVaultCertificateEntity firstRenewal = entities.get(1);
+        final ReadOnlyKeyVaultCertificateEntity secondRenewal = entities.get(2);
+        assertTimestampsAreAdjustedAsExpected(approxNow, recreatedOriginal, INT_800);
+        final OffsetDateTime firstRenewalDay = recreatedOriginal.getExpiry().map(v -> v.minusDays(triggerThresholdDays)).orElseThrow();
+        assertTimestampsAreAdjustedAsExpected(approxNow, firstRenewal, DAYS.between(firstRenewalDay, approxNow));
+        final OffsetDateTime secondRenewalDay = firstRenewal.getExpiry().map(v -> v.minusDays(triggerThresholdDays)).orElseThrow();
+        assertTimestampsAreAdjustedAsExpected(approxNow, secondRenewal, DAYS.between(secondRenewalDay, approxNow));
+        Assertions.assertNotEquals(recreatedOriginal.getKid(), firstRenewal.getKid());
+        Assertions.assertNotEquals(recreatedOriginal.getKid(), secondRenewal.getKid());
+    }
+
+    @Test
+    void testTimeShiftShouldCreateNewVersionsUsingSameKeyWhenAutoRotateIsTriggeredWithActiveCertificatesAllowingKeyReuse() {
+        //given
+        final VaultFakeImpl underTest = new VaultFakeImpl(HTTPS_LOCALHOST);
+        final CertificateVaultFake certificateVaultFake = underTest.certificateVaultFake();
+        final OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+        final OffsetDateTime approxNow = now.plusMinutes(1);
+        final VersionedCertificateEntityId originalCertId = certificateVaultFake
+                .createCertificateVersion(CERT_NAME_1, CertificateCreationInput.builder()
+                        .contentType(CertContentType.PEM)
+                        .name(CERT_NAME_1)
+                        .keyType(KeyType.EC)
+                        .validityStart(approxNow)
+                        .validityMonths(DEFAULT_VALIDITY_MONTHS)
+                        .keyCurveName(KeyCurveName.P_521)
+                        .subject("CN=localhost")
+                        .reuseKeyOnRenewal(true)
+                        .build());
+        final int triggerThresholdDays = 1;
+        certificateVaultFake.setLifetimeActionPolicy(new CertificateLifetimeActionPolicy(
+                originalCertId, Map.of(AUTO_RENEW, new CertificateLifetimeActionTrigger(DAYS_BEFORE_EXPIRY, triggerThresholdDays))
+        ));
+
+        //when
+        underTest.timeShift(SECONDS_IN_800_DAYS, true);
+
+        //then
+        final Deque<String> versions = underTest.certificateVaultFake().getEntities().getVersions(originalCertId);
+        final List<ReadOnlyKeyVaultCertificateEntity> entities = versions.stream()
+                .map(v -> new VersionedCertificateEntityId(originalCertId.vault(), originalCertId.id(), v))
+                .map(certificateVaultFake.getEntities()::getReadOnlyEntity)
+                .collect(Collectors.toList());
+        Assertions.assertEquals(EXPECTED_VERSIONS_AFTER_RENEWAL, entities.size());
+        final ReadOnlyKeyVaultCertificateEntity recreatedOriginal = entities.get(0);
+        final ReadOnlyKeyVaultCertificateEntity firstRenewal = entities.get(1);
+        final ReadOnlyKeyVaultCertificateEntity secondRenewal = entities.get(2);
+        assertTimestampsAreAdjustedAsExpected(approxNow, recreatedOriginal, INT_800);
+        final OffsetDateTime firstRenewalDay = recreatedOriginal.getExpiry().map(v -> v.minusDays(triggerThresholdDays)).orElseThrow();
+        assertTimestampsAreAdjustedAsExpected(approxNow, firstRenewal, DAYS.between(firstRenewalDay, approxNow));
+        final OffsetDateTime secondRenewalDay = firstRenewal.getExpiry().map(v -> v.minusDays(triggerThresholdDays)).orElseThrow();
+        assertTimestampsAreAdjustedAsExpected(approxNow, secondRenewal, DAYS.between(secondRenewalDay, approxNow));
+        Assertions.assertEquals(recreatedOriginal.getKid(), firstRenewal.getKid());
+        Assertions.assertEquals(recreatedOriginal.getKid(), secondRenewal.getKid());
+    }
+
+    @Test
+    void testTimeShiftShouldNotCreateNewVersionsWhenAutoRotateIsTriggeredWithDeletedCertificatesAsTheyArePurged() {
+        //given
+        final VaultFakeImpl underTest = new VaultFakeImpl(HTTPS_LOCALHOST,
+                RecoveryLevel.RECOVERABLE_AND_PURGEABLE, RecoveryLevel.MAX_RECOVERABLE_DAYS_INCLUSIVE);
+        final CertificateVaultFake certificateVaultFake = underTest.certificateVaultFake();
+        final OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+        final OffsetDateTime approxNow = now.plusMinutes(1);
+        final VersionedCertificateEntityId originalCertId = certificateVaultFake
+                .createCertificateVersion(CERT_NAME_1, CertificateCreationInput.builder()
+                        .contentType(CertContentType.PEM)
+                        .name(CERT_NAME_1)
+                        .keyType(KeyType.EC)
+                        .validityStart(approxNow)
+                        .validityMonths(DEFAULT_VALIDITY_MONTHS)
+                        .keyCurveName(KeyCurveName.P_521)
+                        .subject("CN=localhost")
+                        .build());
+        final int triggerThresholdDays = 1;
+        certificateVaultFake.setLifetimeActionPolicy(new CertificateLifetimeActionPolicy(
+                originalCertId, Map.of(AUTO_RENEW, new CertificateLifetimeActionTrigger(DAYS_BEFORE_EXPIRY, triggerThresholdDays))
+        ));
+        certificateVaultFake.delete(originalCertId);
+
+        //when
+        underTest.timeShift(SECONDS_IN_800_DAYS, true);
+
+        //then
+        final boolean exists = underTest.certificateVaultFake().getDeletedEntities().containsName(originalCertId.id());
+        Assertions.assertFalse(exists);
+    }
+
+    @Test
+    void testTimeShiftShouldNotCreateNewVersionsWhenAutoRotateIsTriggeredWithDeletedCertificatesEvenIfNotPurged() {
+        //given
+        final VaultFakeImpl underTest = new VaultFakeImpl(HTTPS_LOCALHOST,
+                RecoveryLevel.RECOVERABLE_AND_PURGEABLE, RecoveryLevel.MAX_RECOVERABLE_DAYS_INCLUSIVE);
+        final CertificateVaultFake certificateVaultFake = underTest.certificateVaultFake();
+        final OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+        final OffsetDateTime approxNow = now.plusMinutes(1);
+        final VersionedCertificateEntityId originalCertId = certificateVaultFake
+                .createCertificateVersion(CERT_NAME_1, CertificateCreationInput.builder()
+                        .contentType(CertContentType.PEM)
+                        .name(CERT_NAME_1)
+                        .keyType(KeyType.EC)
+                        .validityStart(approxNow)
+                        .validityMonths(DEFAULT_VALIDITY_MONTHS)
+                        .keyCurveName(KeyCurveName.P_521)
+                        .subject("CN=localhost")
+                        .build());
+        final int triggerThresholdDays = 1;
+        certificateVaultFake.setLifetimeActionPolicy(new CertificateLifetimeActionPolicy(
+                originalCertId, Map.of(AUTO_RENEW, new CertificateLifetimeActionTrigger(DAYS_BEFORE_EXPIRY, triggerThresholdDays))
+        ));
+        certificateVaultFake.delete(originalCertId);
+
+        //when
+        underTest.timeShift(SECONDS_IN_1_DAY, true);
+
+        //then
+        final Deque<String> versions = underTest.certificateVaultFake().getDeletedEntities().getVersions(originalCertId);
+        Assertions.assertIterableEquals(Set.of(originalCertId.version()), versions);
+    }
+
+    private static void assertTimestampsAreAdjustedAsExpected(
+            final OffsetDateTime approxNow, final ReadOnlyKeyVaultCertificateEntity recreatedOriginal, final long expectedCreationDaysAgo) {
+        Assertions.assertEquals(expectedCreationDaysAgo, DAYS.between(recreatedOriginal.getCreated(), approxNow));
+        Assertions.assertEquals(expectedCreationDaysAgo, DAYS.between(recreatedOriginal.getUpdated(), approxNow));
+        Assertions.assertEquals(expectedCreationDaysAgo, DAYS.between(recreatedOriginal.getNotBefore().orElseThrow(), approxNow));
+        Assertions.assertEquals(DEFAULT_VALIDITY_MONTHS, MONTHS
+                .between(recreatedOriginal.getNotBefore().orElseThrow(), recreatedOriginal.getExpiry().orElseThrow()));
+    }
+}

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/service/vault/impl/VaultFakeImplTest.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/service/vault/impl/VaultFakeImplTest.java
@@ -282,7 +282,7 @@ class VaultFakeImplTest {
                 RecoveryLevel.RECOVERABLE_AND_PROTECTED_SUBSCRIPTION, RecoveryLevel.MAX_RECOVERABLE_DAYS_INCLUSIVE);
 
         //when
-        Assertions.assertThrows(IllegalArgumentException.class, () -> underTest.timeShift(value));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> underTest.timeShift(value, false));
 
         //then + exception
     }
@@ -298,7 +298,7 @@ class VaultFakeImplTest {
         final OffsetDateTime deletedOriginal = underTest.getDeletedOn();
 
         //when
-        underTest.timeShift(NUMBER_OF_SECONDS_IN_10_MINUTES);
+        underTest.timeShift(NUMBER_OF_SECONDS_IN_10_MINUTES, false);
 
         //then
         Assertions.assertEquals(createdOriginal.minusSeconds(NUMBER_OF_SECONDS_IN_10_MINUTES), underTest.getCreatedOn());

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/service/vault/impl/VaultServiceImplTest.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/service/vault/impl/VaultServiceImplTest.java
@@ -333,7 +333,7 @@ class VaultServiceImplTest {
         final VaultServiceImpl underTest = new VaultServiceImpl();
 
         //when
-        Assertions.assertThrows(IllegalArgumentException.class, () -> underTest.timeShift(value));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> underTest.timeShift(value, false));
 
         //then + exception
     }
@@ -346,7 +346,7 @@ class VaultServiceImplTest {
         final OffsetDateTime createdOriginal = vaultFake.getCreatedOn();
 
         //when
-        underTest.timeShift(TestConstants.NUMBER_OF_SECONDS_IN_10_MINUTES);
+        underTest.timeShift(TestConstants.NUMBER_OF_SECONDS_IN_10_MINUTES, false);
 
         //then
         Assertions.assertEquals(createdOriginal.minusSeconds(TestConstants.NUMBER_OF_SECONDS_IN_10_MINUTES), vaultFake.getCreatedOn());

--- a/lowkey-vault-client/src/main/java/com/github/nagyesta/lowkeyvault/http/management/TimeShiftContext.java
+++ b/lowkey-vault-client/src/main/java/com/github/nagyesta/lowkeyvault/http/management/TimeShiftContext.java
@@ -12,11 +12,14 @@ public final class TimeShiftContext {
 
     private final int seconds;
 
+    private final boolean regenerateCertificates;
+
     private final URI vaultBaseUri;
 
-    private TimeShiftContext(final int seconds, final URI vaultBaseUri) {
+    private TimeShiftContext(final int seconds, final URI vaultBaseUri, final boolean regenerateCertificates) {
         this.seconds = seconds;
         this.vaultBaseUri = vaultBaseUri;
+        this.regenerateCertificates = regenerateCertificates;
     }
 
     public static TimeShiftContextBuilder builder() {
@@ -29,6 +32,8 @@ public final class TimeShiftContext {
         private static final int HOURS_PER_DAY = 24;
         private int seconds;
         private URI vaultBaseUri;
+
+        private boolean regenerateCertificates;
 
         TimeShiftContextBuilder() {
         }
@@ -53,13 +58,18 @@ public final class TimeShiftContext {
             return addHours(HOURS_PER_DAY * days);
         }
 
+        public TimeShiftContextBuilder regenerateCertificates() {
+            this.regenerateCertificates = true;
+            return this;
+        }
+
         public TimeShiftContextBuilder vaultBaseUri(@NonNull final URI vaultBaseUri) {
             this.vaultBaseUri = vaultBaseUri;
             return this;
         }
 
         public TimeShiftContext build() {
-            return new TimeShiftContext(seconds, vaultBaseUri);
+            return new TimeShiftContext(seconds, vaultBaseUri, regenerateCertificates);
         }
     }
 }

--- a/lowkey-vault-client/src/main/java/com/github/nagyesta/lowkeyvault/http/management/impl/LowkeyVaultManagementClientImpl.java
+++ b/lowkey-vault-client/src/main/java/com/github/nagyesta/lowkeyvault/http/management/impl/LowkeyVaultManagementClientImpl.java
@@ -44,6 +44,7 @@ public final class LowkeyVaultManagementClientImpl implements LowkeyVaultManagem
     private static final String ALIAS_URI_ADD_QUERY_PARAM = "add";
     private static final String ALIAS_URI_REMOVE_QUERY_PARAM = "remove";
     private static final String SECONDS_QUERY_PARAM = "seconds";
+    private static final String REGENERATE_CERTS_QUERY_PARAM = "regenerateCertificates";
     private final String vaultUrl;
     private final HttpClient instance;
     private final ObjectReader objectReader;
@@ -144,6 +145,9 @@ public final class LowkeyVaultManagementClientImpl implements LowkeyVaultManagem
     public void timeShift(@NonNull final TimeShiftContext context) {
         final Map<String, String> parameters = new TreeMap<>();
         parameters.put(SECONDS_QUERY_PARAM, Integer.toString(context.getSeconds()));
+        if (context.isRegenerateCertificates()) {
+            parameters.put(REGENERATE_CERTS_QUERY_PARAM, Boolean.TRUE.toString());
+        }
         final Optional<URI> optionalURI = Optional.ofNullable(context.getVaultBaseUri());
         optionalURI.ifPresent(uri -> parameters.put(BASE_URI_QUERY_PARAM, uri.toString()));
         final String path = optionalURI.map(u -> MANAGEMENT_VAULT_TIME_PATH).orElse(MANAGEMENT_VAULT_TIME_ALL_PATH);

--- a/lowkey-vault-docker/src/test/java/com/github/nagyesta/lowkeyvault/hook/MissionOutlineDefinition.java
+++ b/lowkey-vault-docker/src/test/java/com/github/nagyesta/lowkeyvault/hook/MissionOutlineDefinition.java
@@ -51,7 +51,7 @@ public class MissionOutlineDefinition extends LaunchAbortHook {
             });
 
             Stream.of("CreateVault", "KeyRotate", "KeyImport", "KeyEncrypt", "KeySign", "CertificateImport",
-                            "CertificateGetPolicy", "RSA", "EC", "OCT")
+                            "CertificateGetPolicy", "CertificateTimeShift", "RSA", "EC", "OCT")
                     .forEach(tag -> {
                         final MissionHealthCheckMatcher matcher = matcher().dependencyWith(tag).extractor(extractor).build();
                         final MissionHealthCheckEvaluator tagPercentage = percentageBasedEvaluator(matcher)

--- a/lowkey-vault-docker/src/test/java/com/github/nagyesta/lowkeyvault/steps/CertificateStepDefAssertion.java
+++ b/lowkey-vault-docker/src/test/java/com/github/nagyesta/lowkeyvault/steps/CertificateStepDefAssertion.java
@@ -84,6 +84,16 @@ public class CertificateStepDefAssertion extends CommonAssertions {
                 certificate.getNotAfter().toInstant().truncatedTo(ChronoUnit.DAYS));
     }
 
+    @And("the downloaded {certContentType} certificate store expires in {int} months - {int} days")
+    public void theDownloadedTypeCertificateStoreExpiresInMonthsMinusDays(
+            final CertificateContentType contentType, final int months, final int days) throws Exception {
+        final String value = secretContext.getLastResult().getValue();
+        final X509Certificate certificate = getX509Certificate(contentType, value);
+        final OffsetDateTime expiry = OffsetDateTime.now().minusDays(days).plusMonths(months);
+        assertEquals(expiry.toInstant().truncatedTo(ChronoUnit.DAYS),
+                certificate.getNotAfter().toInstant().truncatedTo(ChronoUnit.DAYS));
+    }
+
     @And("the downloaded {certContentType} certificate store content matches store from {fileName} using {password} as password")
     public void theDownloadedTypeCertificateStoreContentMatchesStoreFromFileNameUsingPassword(
             final CertificateContentType contentType, final String resource, final String password) throws Exception {

--- a/lowkey-vault-docker/src/test/java/com/github/nagyesta/lowkeyvault/steps/CertificatesStepDefs.java
+++ b/lowkey-vault-docker/src/test/java/com/github/nagyesta/lowkeyvault/steps/CertificatesStepDefs.java
@@ -124,6 +124,11 @@ public class CertificatesStepDefs extends CommonAssertions {
         context.getPolicy().setEnabled(enabledStatus);
     }
 
+    @Given("the certificate is set to expire in {int} months")
+    public void theKeyIsSetToBeEnabledStatus(final int expiryMonths) {
+        context.getPolicy().setValidityInMonths(expiryMonths);
+    }
+
     @When("a certificate named {name} is imported from the resource named {fileName} using {password} as password")
     public void aCertificateIsImportedWithNameFromTheResourceUsingPassword(
             final String name, final String resource, final String password) throws IOException {

--- a/lowkey-vault-docker/src/test/java/com/github/nagyesta/lowkeyvault/steps/ManagementStepDefs.java
+++ b/lowkey-vault-docker/src/test/java/com/github/nagyesta/lowkeyvault/steps/ManagementStepDefs.java
@@ -101,6 +101,7 @@ public class ManagementStepDefs extends CommonAssertions {
         final String vaultUrl = vaultNameToUrl(vaultName);
         context.getClient().timeShift(TimeShiftContext.builder()
                 .vaultBaseUri(URI.create(vaultUrl))
+                .regenerateCertificates()
                 .addDays(timeShiftDays)
                 .build());
     }

--- a/lowkey-vault-docker/src/test/resources/com/github/nagyesta/lowkeyvault/certificates/CreateCertificates.feature
+++ b/lowkey-vault-docker/src/test/resources/com/github/nagyesta/lowkeyvault/certificates/CreateCertificates.feature
@@ -73,9 +73,10 @@ Feature: Certificate creation
         And the downloaded <type> certificate store has a certificate with CN=localhost as subject
 
         Examples:
-            | api | certName                   | triggerValue | triggerType        | action        | type   |
-            | 7.3 | 73-createRsaCertPemAction  | 20           | days before expiry | EmailContacts | PEM    |
-            | 7.3 | 73-createRsaCertPkcsAction | 75           | percent lifetime   | AutoRenew     | PKCS12 |
+            | api | certName                       | triggerValue | triggerType        | action        | type   |
+            | 7.3 | 73-createRsaCertPemAction      | 20           | days before expiry | EmailContacts | PEM    |
+            | 7.3 | 73-createRsaCertPkcsAction     | 75           | percent lifetime   | AutoRenew     | PKCS12 |
+            | 7.3 | 73-createRsaCertPemRenewAction | 75           | percent lifetime   | AutoRenew     | PEM    |
 
     @Certificate @CertificateCreate @EC
     Scenario Outline: EC_CERT_CREATE_02 Single versions of EC certificates can be created using lifetime actions

--- a/lowkey-vault-docker/src/test/resources/com/github/nagyesta/lowkeyvault/certificates/RenewCertificates.feature
+++ b/lowkey-vault-docker/src/test/resources/com/github/nagyesta/lowkeyvault/certificates/RenewCertificates.feature
@@ -1,0 +1,49 @@
+Feature: Certificate renewal/recreation
+
+    @Certificate @CertificateCreate @CertificateTimeShift @RSA
+    Scenario Outline: RSA_CERT_TIME_SHIFT_01 Single versions of RSA certificates can be recreated or renewed with time shift
+        Given certificate API version <api> is used
+        And a vault is created with name certs-time-shift-rsa-<index>
+        And a certificate client is created with the vault named certs-time-shift-rsa-<index>
+        And a <type> certificate is prepared with subject <subject>
+        And the certificate is set to expire in <expiryMonths> months
+        And the lifetime action trigger is set to AutoRenew when 1 days before expiry reached
+        And the certificate is set to be enabled
+        And the certificate is set to use an RSA key with 2048 and without HSM
+        And the certificate is created with name <certName>
+        When the time of the vault named certs-time-shift-rsa-<index> is shifted by <shiftDays> days
+        Then the certificate is enabled
+        And the certificate secret named <certName> is downloaded
+        And the downloaded secret contains a <type> certificate
+        And the downloaded <type> certificate store expires in <adjustmentMonths> months - <adjustmentDays> days
+        And the downloaded <type> certificate store has a certificate with <subject> as subject
+
+
+        Examples:
+            | api | index | certName           | type | subject        | expiryMonths | shiftDays | adjustmentDays | adjustmentMonths |
+            | 7.3 | 1     | 73-recreateRsaCert | PEM  | CN=localhost   | 20           | 100       | 100            | 20               |
+            | 7.3 | 2     | 73-renewRsaCert    | PEM  | CN=example.com | 5            | 360       | 362            | 15               |
+
+    @Certificate @CertificateCreate @CertificateTimeShift @EC
+    Scenario Outline: EC_CERT_TIME_SHIFT_01 Single versions of EC certificates can be recreated or renewed with time shift
+        Given certificate API version <api> is used
+        And a vault is created with name certs-time-shift-ec-<index>
+        And a certificate client is created with the vault named certs-time-shift-ec-<index>
+        And a <type> certificate is prepared with subject <subject>
+        And the certificate is set to expire in <expiryMonths> months
+        And the lifetime action trigger is set to AutoRenew when 1 days before expiry reached
+        And the certificate is set to be enabled
+        And the certificate is set to use an EC key with P-521 and without HSM
+        And the certificate is created with name <certName>
+        When the time of the vault named certs-time-shift-ec-<index> is shifted by <shiftDays> days
+        Then the certificate is enabled
+        And the certificate secret named <certName> is downloaded
+        And the downloaded secret contains a <type> certificate
+        And the downloaded <type> certificate store expires in <adjustmentMonths> months - <adjustmentDays> days
+        And the downloaded <type> certificate store has a certificate with <subject> as subject
+
+
+        Examples:
+            | api | index | certName          | type | subject        | expiryMonths | shiftDays | adjustmentDays | adjustmentMonths |
+            | 7.3 | 1     | 73-recreateEcCert | PEM  | CN=localhost   | 20           | 100       | 100            | 20               |
+            | 7.3 | 2     | 73-renewEcCert    | PEM  | CN=example.com | 5            | 360       | 362            | 15               |


### PR DESCRIPTION
__Issue:__ #481 <!-- #issue number -->

### Description
<!-- A short summary of changes -->

- Adds new parameter to time shift endpoints to allow regeneration of certificates
- Regenerates certificates if time shift requires it
- Performs automatic certificate renewals during time shift based on lifetime actions
- Rotate non-reusable keys during automatic certificate renewals
- Updates timestamps of backing keys/secrets based on calculated validity start/end of certificate
- Updates client to support new time shift parameter
- Covers new functionality with UT/IT
- Adds new end-2-end tests
- Updates documentation

### Entry point
<!-- Where should the reviewer start in order to properly understand the PR? -->

-

### Checklists

- [x] I have rebased my branch
- [x] My commit message is meaningful
- [x] The commit messages use semantic versioning: ```{major}```, ```{minor}``` or ```{patch}```
- [x] The changes are focusing on the issue at hand
- [x] I have maintained or increased test coverage

### Notes

-
<!-- Any additional remarks you may have. -->
