### PR TITLE
Inconsistency when signing data

### DIFF
--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/model/v7_2/key/constants/HashAlgorithm.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/model/v7_2/key/constants/HashAlgorithm.java
@@ -1,0 +1,57 @@
+package com.github.nagyesta.lowkeyvault.model.v7_2.key.constants;
+
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
+import org.bouncycastle.asn1.DERNull;
+import org.bouncycastle.asn1.nist.NISTObjectIdentifiers;
+import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
+import org.bouncycastle.asn1.x509.DigestInfo;
+import org.springframework.util.Assert;
+
+import java.io.IOException;
+import java.lang.reflect.Array;
+import java.security.spec.MGF1ParameterSpec;
+import java.security.spec.PSSParameterSpec;
+import java.util.Optional;
+
+@SuppressWarnings("checkstyle:JavadocVariable")
+public enum HashAlgorithm {
+    SHA256("SHA-256", 32, NISTObjectIdentifiers.id_sha256),
+    SHA384("SHA-384", 48, NISTObjectIdentifiers.id_sha384),
+    SHA512("SHA-512", 64, NISTObjectIdentifiers.id_sha512);
+
+    private final String algorithmName;
+    private final ASN1ObjectIdentifier algorithmIdentifier;
+    private final int digestLength;
+
+    HashAlgorithm(final String algorithmName, final int digestLength, final ASN1ObjectIdentifier algorithmIdentifier) {
+        this.algorithmName = algorithmName;
+        this.algorithmIdentifier = algorithmIdentifier;
+        this.digestLength = digestLength;
+    }
+
+    public String getAlgorithmName() {
+        return algorithmName;
+    }
+
+    public byte[] encodeDigest(final byte[] digest) throws IOException {
+        return new DigestInfo(new AlgorithmIdentifier(algorithmIdentifier, DERNull.INSTANCE), digest).getEncoded();
+    }
+
+    public PSSParameterSpec getPssParameter() {
+        return new PSSParameterSpec(
+                algorithmName,
+                "MGF1",
+                new MGF1ParameterSpec(algorithmName),
+                digestLength,
+                PSSParameterSpec.TRAILER_FIELD_BC
+        );
+    }
+
+    public void verifyDigestLength(final byte[] digest) {
+        final int length = Optional.ofNullable(digest)
+                .map(Array::getLength)
+                .orElseThrow(() -> new IllegalArgumentException("Digest is null."));
+        Assert.isTrue(digestLength == length,
+                "This algorithm does not support digest length: " + length + ". Expected: " + digestLength);
+    }
+}

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/model/v7_2/key/constants/SignatureAlgorithm.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/model/v7_2/key/constants/SignatureAlgorithm.java
@@ -3,76 +3,116 @@ package com.github.nagyesta.lowkeyvault.model.v7_2.key.constants;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.github.nagyesta.lowkeyvault.service.key.util.KeyGenUtil;
 
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.security.Signature;
 import java.util.Arrays;
 
 @SuppressWarnings("checkstyle:JavadocVariable")
 public enum SignatureAlgorithm {
 
-    ES256("ES256", "NONEwithECDSAinP1363Format", KeyType.EC) {
+    ES256("ES256", "NONEwithECDSAinP1363Format", KeyType.EC, HashAlgorithm.SHA256) {
         @Override
         public boolean isCompatibleWithCurve(final KeyCurveName keyCurveName) {
             return KeyCurveName.P_256 == keyCurveName;
         }
 
-        @SuppressWarnings("checkstyle:MagicNumber")
         @Override
-        public boolean supportsDigestLength(final int digestLength) {
-            return digestLength == 32;
+        public Signature getSignatureInstance() throws GeneralSecurityException {
+            return Signature.getInstance(getAlg());
         }
     },
-    ES256K("ES256K", "NONEwithECDSAinP1363Format", KeyType.EC) {
+    ES256K("ES256K", "NONEwithECDSAinP1363Format", KeyType.EC, HashAlgorithm.SHA256) {
         @Override
         public boolean isCompatibleWithCurve(final KeyCurveName keyCurveName) {
             return KeyCurveName.P_256K == keyCurveName;
         }
 
-        @SuppressWarnings("checkstyle:MagicNumber")
         @Override
-        public boolean supportsDigestLength(final int digestLength) {
-            return digestLength == 32;
+        public Signature getSignatureInstance() throws GeneralSecurityException {
+            return Signature.getInstance(getAlg());
         }
     },
-    ES384("ES384", "NONEwithECDSAinP1363Format", KeyType.EC) {
+    ES384("ES384", "NONEwithECDSAinP1363Format", KeyType.EC, HashAlgorithm.SHA384) {
         @Override
         public boolean isCompatibleWithCurve(final KeyCurveName keyCurveName) {
             return KeyCurveName.P_384 == keyCurveName;
         }
 
-        @SuppressWarnings("checkstyle:MagicNumber")
         @Override
-        public boolean supportsDigestLength(final int digestLength) {
-            return digestLength == 48;
+        public Signature getSignatureInstance() throws GeneralSecurityException {
+            return Signature.getInstance(getAlg());
         }
     },
-    ES512("ES512", "NONEwithECDSAinP1363Format", KeyType.EC) {
+    ES512("ES512", "NONEwithECDSAinP1363Format", KeyType.EC, HashAlgorithm.SHA512) {
         @Override
         public boolean isCompatibleWithCurve(final KeyCurveName keyCurveName) {
             return KeyCurveName.P_521 == keyCurveName;
         }
 
-        @SuppressWarnings("checkstyle:MagicNumber")
         @Override
-        public boolean supportsDigestLength(final int digestLength) {
-            return digestLength == 64;
+        public Signature getSignatureInstance() throws GeneralSecurityException {
+            return Signature.getInstance(getAlg());
         }
     },
-    PS256("PS256", "SHA256withRSAandMGF1", KeyType.RSA),
-    PS384("PS384", "SHA384withRSAandMGF1", KeyType.RSA),
-    PS512("PS512", "SHA512withRSAandMGF1", KeyType.RSA),
-    RS256("RS256", "SHA256withRSA", KeyType.RSA),
-    RS384("RS384", "SHA384withRSA", KeyType.RSA),
-    RS512("RS512", "SHA512withRSA", KeyType.RSA);
+    PS256("PS256", "NONEwithRSAandMGF1", KeyType.RSA, HashAlgorithm.SHA256) {
+        @Override
+        public Signature getSignatureInstance() throws GeneralSecurityException {
+            final Signature signature = super.getSignatureInstance();
+            signature.setParameter(getHashAlgorithm().getPssParameter());
+            return signature;
+        }
+    },
+    PS384("PS384", "NONEwithRSAandMGF1", KeyType.RSA, HashAlgorithm.SHA384) {
+        @Override
+        public Signature getSignatureInstance() throws GeneralSecurityException {
+            final Signature signature = super.getSignatureInstance();
+            signature.setParameter(getHashAlgorithm().getPssParameter());
+            return signature;
+        }
+    },
+    PS512("PS512", "NONEwithRSAandMGF1", KeyType.RSA, HashAlgorithm.SHA512) {
+        @Override
+        public Signature getSignatureInstance() throws GeneralSecurityException {
+            final Signature signature = super.getSignatureInstance();
+            signature.setParameter(getHashAlgorithm().getPssParameter());
+            return signature;
+        }
+    },
+    RS256("RS256", "NoneWithRSA", KeyType.RSA, HashAlgorithm.SHA256) {
+        @Override
+        public byte[] transformDigest(final byte[] digest) throws IOException {
+            return getHashAlgorithm().encodeDigest(digest);
+        }
+    },
+    RS384("RS384", "NoneWithRSA", KeyType.RSA, HashAlgorithm.SHA384) {
+        @Override
+        public byte[] transformDigest(final byte[] digest) throws IOException {
+            return getHashAlgorithm().encodeDigest(digest);
+        }
+    },
+    RS512("RS512", "NoneWithRSA", KeyType.RSA, HashAlgorithm.SHA512) {
+        @Override
+        public byte[] transformDigest(final byte[] digest) throws IOException {
+            return getHashAlgorithm().encodeDigest(digest);
+        }
+    };
 
     private final String value;
     private final String alg;
     private final KeyType compatibleType;
+    private final HashAlgorithm hashAlgorithm;
 
     SignatureAlgorithm(final String value,
-                       final String alg, final KeyType compatibleType) {
+                       final String alg,
+                       final KeyType compatibleType,
+                       final HashAlgorithm hashAlgorithm) {
         this.value = value;
         this.alg = alg;
         this.compatibleType = compatibleType;
+        this.hashAlgorithm = hashAlgorithm;
     }
 
     @JsonCreator
@@ -101,8 +141,17 @@ public enum SignatureAlgorithm {
     }
 
     @JsonIgnore
-    public boolean supportsDigestLength(final int digestLength) {
-        return false;
+    public byte[] transformDigest(final byte[] digest) throws IOException {
+        return digest;
     }
 
+    @JsonIgnore
+    public HashAlgorithm getHashAlgorithm() {
+        return hashAlgorithm;
+    }
+
+    @JsonIgnore
+    public Signature getSignatureInstance() throws GeneralSecurityException {
+        return Signature.getInstance(getAlg(), KeyGenUtil.BOUNCY_CASTLE_PROVIDER);
+    }
 }

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/HashUtil.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/HashUtil.java
@@ -1,0 +1,26 @@
+package com.github.nagyesta.lowkeyvault;
+
+import com.github.nagyesta.lowkeyvault.model.v7_2.key.constants.HashAlgorithm;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+public final class HashUtil {
+
+    private HashUtil() {
+    }
+
+    public static byte[] hash(final byte[] data, final HashAlgorithm algorithm) {
+        try {
+            return hash(data, algorithm.getAlgorithmName());
+        } catch (final NoSuchAlgorithmException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    private static byte[] hash(final byte[] data, final String algorithm) throws NoSuchAlgorithmException {
+        final MessageDigest md = MessageDigest.getInstance(algorithm);
+        md.update(data);
+        return md.digest();
+    }
+}

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/controller/v7_2/KeyCryptoControllerTest.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/controller/v7_2/KeyCryptoControllerTest.java
@@ -1,15 +1,13 @@
 package com.github.nagyesta.lowkeyvault.controller.v7_2;
 
+import com.github.nagyesta.lowkeyvault.HashUtil;
 import com.github.nagyesta.lowkeyvault.mapper.common.registry.KeyConverterRegistry;
 import com.github.nagyesta.lowkeyvault.mapper.v7_2.key.KeyEntityToV72KeyItemModelConverter;
 import com.github.nagyesta.lowkeyvault.mapper.v7_2.key.KeyEntityToV72KeyVersionItemModelConverter;
 import com.github.nagyesta.lowkeyvault.mapper.v7_2.key.KeyEntityToV72ModelConverter;
 import com.github.nagyesta.lowkeyvault.model.common.ApiConstants;
 import com.github.nagyesta.lowkeyvault.model.v7_2.key.*;
-import com.github.nagyesta.lowkeyvault.model.v7_2.key.constants.EncryptionAlgorithm;
-import com.github.nagyesta.lowkeyvault.model.v7_2.key.constants.KeyOperation;
-import com.github.nagyesta.lowkeyvault.model.v7_2.key.constants.KeyType;
-import com.github.nagyesta.lowkeyvault.model.v7_2.key.constants.SignatureAlgorithm;
+import com.github.nagyesta.lowkeyvault.model.v7_2.key.constants.*;
 import com.github.nagyesta.lowkeyvault.model.v7_2.key.request.CreateKeyRequest;
 import com.github.nagyesta.lowkeyvault.model.v7_2.key.request.KeyOperationsParameters;
 import com.github.nagyesta.lowkeyvault.model.v7_2.key.request.KeySignParameters;
@@ -192,7 +190,7 @@ class KeyCryptoControllerTest {
                 .thenReturn(RESPONSE);
         final KeySignParameters keySignParameters = new KeySignParameters();
         keySignParameters.setAlgorithm(SignatureAlgorithm.PS256);
-        keySignParameters.setValue(ENCODER.encodeToString(clearText.getBytes(StandardCharsets.UTF_8)));
+        keySignParameters.setValue(ENCODER.encodeToString(HashUtil.hash(clearText.getBytes(StandardCharsets.UTF_8), HashAlgorithm.SHA256)));
 
         //when
         final ResponseEntity<KeySignResult> signature = underTest
@@ -204,7 +202,7 @@ class KeyCryptoControllerTest {
 
         final KeyVerifyParameters verifyParameters = new KeyVerifyParameters();
         verifyParameters.setAlgorithm(SignatureAlgorithm.PS256);
-        verifyParameters.setDigest(ENCODER.encodeToString(clearText.getBytes(StandardCharsets.UTF_8)));
+        verifyParameters.setDigest(ENCODER.encodeToString(HashUtil.hash(clearText.getBytes(StandardCharsets.UTF_8), HashAlgorithm.SHA256)));
         verifyParameters.setValue(signature.getBody().getValue());
         final ResponseEntity<KeyVerifyResult> actual = underTest
                 .verify(KEY_NAME_1, KEY_VERSION_3, HTTPS_LOCALHOST_8443, verifyParameters);

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/controller/v7_3/KeyCryptoControllerTest.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/controller/v7_3/KeyCryptoControllerTest.java
@@ -1,15 +1,13 @@
 package com.github.nagyesta.lowkeyvault.controller.v7_3;
 
+import com.github.nagyesta.lowkeyvault.HashUtil;
 import com.github.nagyesta.lowkeyvault.mapper.common.registry.KeyConverterRegistry;
 import com.github.nagyesta.lowkeyvault.mapper.v7_2.key.KeyEntityToV72KeyItemModelConverter;
 import com.github.nagyesta.lowkeyvault.mapper.v7_2.key.KeyEntityToV72KeyVersionItemModelConverter;
 import com.github.nagyesta.lowkeyvault.mapper.v7_2.key.KeyEntityToV72ModelConverter;
 import com.github.nagyesta.lowkeyvault.model.common.ApiConstants;
 import com.github.nagyesta.lowkeyvault.model.v7_2.key.*;
-import com.github.nagyesta.lowkeyvault.model.v7_2.key.constants.EncryptionAlgorithm;
-import com.github.nagyesta.lowkeyvault.model.v7_2.key.constants.KeyOperation;
-import com.github.nagyesta.lowkeyvault.model.v7_2.key.constants.KeyType;
-import com.github.nagyesta.lowkeyvault.model.v7_2.key.constants.SignatureAlgorithm;
+import com.github.nagyesta.lowkeyvault.model.v7_2.key.constants.*;
 import com.github.nagyesta.lowkeyvault.model.v7_2.key.request.CreateKeyRequest;
 import com.github.nagyesta.lowkeyvault.model.v7_2.key.request.KeyOperationsParameters;
 import com.github.nagyesta.lowkeyvault.model.v7_2.key.request.KeySignParameters;
@@ -196,7 +194,7 @@ class KeyCryptoControllerTest {
                 .thenReturn(RESPONSE);
         final KeySignParameters keySignParameters = new KeySignParameters();
         keySignParameters.setAlgorithm(SignatureAlgorithm.PS256);
-        keySignParameters.setValue(ENCODER.encodeToString(clearText.getBytes(StandardCharsets.UTF_8)));
+        keySignParameters.setValue(ENCODER.encodeToString(HashUtil.hash(clearText.getBytes(StandardCharsets.UTF_8), HashAlgorithm.SHA256)));
 
         //when
         final ResponseEntity<KeySignResult> signature = underTest
@@ -208,7 +206,7 @@ class KeyCryptoControllerTest {
 
         final KeyVerifyParameters verifyParameters = new KeyVerifyParameters();
         verifyParameters.setAlgorithm(SignatureAlgorithm.PS256);
-        verifyParameters.setDigest(ENCODER.encodeToString(clearText.getBytes(StandardCharsets.UTF_8)));
+        verifyParameters.setDigest(ENCODER.encodeToString(HashUtil.hash(clearText.getBytes(StandardCharsets.UTF_8), HashAlgorithm.SHA256)));
         verifyParameters.setValue(signature.getBody().getValue());
         final ResponseEntity<KeyVerifyResult> actual = underTest
                 .verify(KEY_NAME_1, KEY_VERSION_3, HTTPS_LOCALHOST_8443, verifyParameters);

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/model/v7_2/key/constants/SignatureAlgorithmTest.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/model/v7_2/key/constants/SignatureAlgorithmTest.java
@@ -58,19 +58,6 @@ class SignatureAlgorithmTest {
         Assertions.assertFalse(actual);
     }
 
-
-    @Test
-    void testSupportsDigestLengthShouldReturnFalseInCaseOfRsaAlgorithm() {
-        //given
-        final SignatureAlgorithm underTest = SignatureAlgorithm.PS256;
-
-        //when
-        final boolean actual = underTest.supportsDigestLength(0);
-
-        //then
-        Assertions.assertFalse(actual);
-    }
-
     @ParameterizedTest
     @MethodSource("valueProvider")
     void testForValueShouldReturnExpectedAlgorithmWhenCalled(final String inout, final SignatureAlgorithm expected) {
@@ -78,19 +65,6 @@ class SignatureAlgorithmTest {
 
         //when
         final SignatureAlgorithm actual = SignatureAlgorithm.forValue(inout);
-
-        //then
-        Assertions.assertEquals(expected, actual);
-    }
-
-    @ParameterizedTest
-    @MethodSource("digestLengthProvider")
-    void testSupportsDigestLengthShouldReturnTrueOnlyWhenCalledWithExpectedDigest(
-            final SignatureAlgorithm underTest, final int input, final boolean expected) {
-        //given
-
-        //when
-        final boolean actual = underTest.supportsDigestLength(input);
 
         //then
         Assertions.assertEquals(expected, actual);

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/service/key/impl/EcKeyVaultKeyEntityTest.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/service/key/impl/EcKeyVaultKeyEntityTest.java
@@ -1,12 +1,11 @@
 package com.github.nagyesta.lowkeyvault.service.key.impl;
 
-import com.github.nagyesta.lowkeyvault.model.v7_2.key.constants.KeyCurveName;
-import com.github.nagyesta.lowkeyvault.model.v7_2.key.constants.KeyOperation;
-import com.github.nagyesta.lowkeyvault.model.v7_2.key.constants.KeyType;
-import com.github.nagyesta.lowkeyvault.model.v7_2.key.constants.SignatureAlgorithm;
+import com.github.nagyesta.lowkeyvault.HashUtil;
+import com.github.nagyesta.lowkeyvault.model.v7_2.key.constants.*;
 import com.github.nagyesta.lowkeyvault.service.key.id.VersionedKeyEntityId;
 import com.github.nagyesta.lowkeyvault.service.vault.VaultFake;
 import com.github.nagyesta.lowkeyvault.service.vault.impl.VaultFakeImpl;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -15,11 +14,10 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.NullSource;
 
 import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.Signature;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Stream;
 
 import static com.github.nagyesta.lowkeyvault.TestConstants.*;
@@ -28,15 +26,6 @@ import static com.github.nagyesta.lowkeyvault.TestConstantsUri.HTTPS_LOWKEY_VAUL
 import static org.mockito.Mockito.mock;
 
 class EcKeyVaultKeyEntityTest {
-
-    private static final String SHA_256 = "SHA-256";
-    private static final String SHA_384 = "SHA-384";
-    private static final String SHA_512 = "SHA-512";
-    private static final Map<SignatureAlgorithm, String> HASH_ALGORITHMS = Map.of(
-            SignatureAlgorithm.ES256, SHA_256,
-            SignatureAlgorithm.ES256K, SHA_256,
-            SignatureAlgorithm.ES384, SHA_384,
-            SignatureAlgorithm.ES512, SHA_512);
 
     public static Stream<Arguments> invalidValueProvider() {
         return Stream.<Arguments>builder()
@@ -61,10 +50,23 @@ class EcKeyVaultKeyEntityTest {
                                 .build()));
     }
 
-    public static Stream<Arguments> digestSource() {
+    public static Stream<Arguments> byteArraySource() {
         final Object bytes = DEFAULT_VAULT.getBytes(StandardCharsets.UTF_8);
         return Stream.<Arguments>builder()
                 .add(Arguments.of(bytes))
+                .build();
+    }
+
+    public static Stream<Arguments> signDigestSource() {
+        final byte[] bytes = DEFAULT_VAULT.getBytes(StandardCharsets.UTF_8);
+        final byte[] sha256Digest = HashUtil.hash(bytes, HashAlgorithm.SHA256);
+        final byte[] sha384Digest = HashUtil.hash(bytes, HashAlgorithm.SHA384);
+        final byte[] sha512Digest = HashUtil.hash(bytes, HashAlgorithm.SHA512);
+        return Stream.<Arguments>builder()
+                .add(Arguments.of(bytes, sha256Digest, KeyCurveName.P_256, SignatureAlgorithm.ES256, "SHA256withPLAIN-ECDSA"))
+                .add(Arguments.of(bytes, sha256Digest, KeyCurveName.P_256K, SignatureAlgorithm.ES256K, "SHA256withPLAIN-ECDSA"))
+                .add(Arguments.of(bytes, sha384Digest, KeyCurveName.P_384, SignatureAlgorithm.ES384, "SHA384withPLAIN-ECDSA"))
+                .add(Arguments.of(bytes, sha512Digest, KeyCurveName.P_521, SignatureAlgorithm.ES512, "SHA512withPLAIN-ECDSA"))
                 .build();
     }
 
@@ -106,8 +108,8 @@ class EcKeyVaultKeyEntityTest {
                 VERSIONED_KEY_ENTITY_ID_1_VERSION_1, vaultFake, keyCurveName, false);
         underTest.setOperations(List.of(KeyOperation.SIGN, KeyOperation.VERIFY));
         underTest.setEnabled(true);
-        final byte[] cipherSign = hash(clearSign.getBytes(StandardCharsets.UTF_8), algorithm);
-        final byte[] cipherVerify = hash(clearVerify.getBytes(StandardCharsets.UTF_8), algorithm);
+        final byte[] cipherSign = HashUtil.hash(clearSign.getBytes(StandardCharsets.UTF_8), algorithm.getHashAlgorithm());
+        final byte[] cipherVerify = HashUtil.hash(clearVerify.getBytes(StandardCharsets.UTF_8), algorithm.getHashAlgorithm());
 
         //when
         final byte[] signature = underTest.signBytes(cipherSign, algorithm);
@@ -115,6 +117,26 @@ class EcKeyVaultKeyEntityTest {
 
         //then
         Assertions.assertEquals(clearSign.equals(clearVerify), actual);
+    }
+
+    @ParameterizedTest
+    @MethodSource("signDigestSource")
+    void testSignShouldProduceTheExpectedSignatureWhenCalledWithValidData(
+            final byte[] original, final byte[] digest, final KeyCurveName keyCurveName,
+            final SignatureAlgorithm algorithm, final String verifyAlgorithm) throws Exception {
+        //given
+        final VaultFake vaultFake = new VaultFakeImpl(HTTPS_LOWKEY_VAULT);
+        final EcKeyVaultKeyEntity underTest = new EcKeyVaultKeyEntity(
+                VERSIONED_KEY_ENTITY_ID_1_VERSION_1, vaultFake, keyCurveName, false);
+        underTest.setOperations(List.of(KeyOperation.SIGN, KeyOperation.VERIFY));
+        underTest.setEnabled(true);
+
+        //when
+        final byte[] signature = underTest.signBytes(digest, algorithm);
+
+        //then
+        final boolean actual = checkSignature(underTest.getKey().getPublic(), signature, original, verifyAlgorithm);
+        Assertions.assertTrue(actual);
     }
 
     @Test
@@ -125,7 +147,7 @@ class EcKeyVaultKeyEntityTest {
                 VERSIONED_KEY_ENTITY_ID_1_VERSION_1, vaultFake, KeyCurveName.P_256, false);
         underTest.setOperations(List.of(KeyOperation.VERIFY));
         underTest.setEnabled(true);
-        final byte[] digest = hash(DEFAULT_VAULT.getBytes(StandardCharsets.UTF_8), SignatureAlgorithm.ES256);
+        final byte[] digest = HashUtil.hash(DEFAULT_VAULT.getBytes(StandardCharsets.UTF_8), SignatureAlgorithm.ES256.getHashAlgorithm());
 
         //when
         Assertions.assertThrows(IllegalStateException.class,
@@ -142,7 +164,7 @@ class EcKeyVaultKeyEntityTest {
                 VERSIONED_KEY_ENTITY_ID_1_VERSION_1, vaultFake, KeyCurveName.P_256, false);
         underTest.setOperations(List.of(KeyOperation.SIGN));
         underTest.setEnabled(true);
-        final byte[] digest = hash(DEFAULT_VAULT.getBytes(StandardCharsets.UTF_8), SignatureAlgorithm.ES256);
+        final byte[] digest = HashUtil.hash(DEFAULT_VAULT.getBytes(StandardCharsets.UTF_8), SignatureAlgorithm.ES256.getHashAlgorithm());
 
         //when
         final byte[] signature = underTest.signBytes(digest, SignatureAlgorithm.ES256);
@@ -160,7 +182,7 @@ class EcKeyVaultKeyEntityTest {
                 VERSIONED_KEY_ENTITY_ID_1_VERSION_1, vaultFake, KeyCurveName.P_256, false);
         underTest.setOperations(List.of(KeyOperation.SIGN, KeyOperation.VERIFY));
         underTest.setEnabled(false);
-        final byte[] digest = hash(DEFAULT_VAULT.getBytes(StandardCharsets.UTF_8), SignatureAlgorithm.ES256);
+        final byte[] digest = HashUtil.hash(DEFAULT_VAULT.getBytes(StandardCharsets.UTF_8), SignatureAlgorithm.ES256.getHashAlgorithm());
 
         //when
         Assertions.assertThrows(IllegalStateException.class,
@@ -177,7 +199,7 @@ class EcKeyVaultKeyEntityTest {
                 VERSIONED_KEY_ENTITY_ID_1_VERSION_1, vaultFake, KeyCurveName.P_256, false);
         underTest.setOperations(List.of(KeyOperation.SIGN, KeyOperation.VERIFY));
         underTest.setEnabled(true);
-        final byte[] digest = hash(DEFAULT_VAULT.getBytes(StandardCharsets.UTF_8), SignatureAlgorithm.ES256);
+        final byte[] digest = HashUtil.hash(DEFAULT_VAULT.getBytes(StandardCharsets.UTF_8), SignatureAlgorithm.ES256.getHashAlgorithm());
 
         //when
         final byte[] signature = underTest.signBytes(digest, SignatureAlgorithm.ES256);
@@ -196,7 +218,7 @@ class EcKeyVaultKeyEntityTest {
                 VERSIONED_KEY_ENTITY_ID_1_VERSION_1, vaultFake, KeyCurveName.P_256, false);
         underTest.setOperations(List.of(KeyOperation.SIGN, KeyOperation.VERIFY));
         underTest.setEnabled(true);
-        final byte[] digest = hash(DEFAULT_VAULT.getBytes(StandardCharsets.UTF_8), SignatureAlgorithm.ES256);
+        final byte[] digest = HashUtil.hash(DEFAULT_VAULT.getBytes(StandardCharsets.UTF_8), SignatureAlgorithm.ES256.getHashAlgorithm());
 
         //when
         Assertions.assertThrows(IllegalStateException.class,
@@ -213,7 +235,7 @@ class EcKeyVaultKeyEntityTest {
                 VERSIONED_KEY_ENTITY_ID_1_VERSION_1, vaultFake, KeyCurveName.P_256, false);
         underTest.setOperations(List.of(KeyOperation.SIGN, KeyOperation.VERIFY));
         underTest.setEnabled(true);
-        final byte[] digest = hash(DEFAULT_VAULT.getBytes(StandardCharsets.UTF_8), SignatureAlgorithm.ES256);
+        final byte[] digest = HashUtil.hash(DEFAULT_VAULT.getBytes(StandardCharsets.UTF_8), SignatureAlgorithm.ES256.getHashAlgorithm());
 
         //when
         final byte[] signature = underTest.signBytes(digest, SignatureAlgorithm.ES256);
@@ -224,7 +246,7 @@ class EcKeyVaultKeyEntityTest {
     }
 
     @ParameterizedTest
-    @MethodSource("digestSource")
+    @MethodSource("byteArraySource")
     @NullSource
     void testSignShouldThrowExceptionWhenWhenDigestSizeIsNotCompatible(final byte[] digest) {
         //given
@@ -242,7 +264,7 @@ class EcKeyVaultKeyEntityTest {
     }
 
     @ParameterizedTest
-    @MethodSource("digestSource")
+    @MethodSource("byteArraySource")
     @NullSource
     void testVerifyShouldThrowExceptionWhenWhenDigestSizeIsNotCompatible(final byte[] digest) {
         //given
@@ -251,7 +273,7 @@ class EcKeyVaultKeyEntityTest {
                 VERSIONED_KEY_ENTITY_ID_1_VERSION_1, vaultFake, KeyCurveName.P_256, false);
         underTest.setOperations(List.of(KeyOperation.SIGN, KeyOperation.VERIFY));
         underTest.setEnabled(true);
-        final byte[] hash = hash(DEFAULT_VAULT.getBytes(StandardCharsets.UTF_8), SignatureAlgorithm.ES256);
+        final byte[] hash = HashUtil.hash(DEFAULT_VAULT.getBytes(StandardCharsets.UTF_8), SignatureAlgorithm.ES256.getHashAlgorithm());
 
         //when
         final byte[] signature = underTest.signBytes(hash, SignatureAlgorithm.ES256);
@@ -278,13 +300,12 @@ class EcKeyVaultKeyEntityTest {
         Assertions.assertEquals(keyCurveName, value.getKeyParameter());
     }
 
-    private byte[] hash(final byte[] text, final SignatureAlgorithm algorithm) {
-        try {
-            final MessageDigest md = MessageDigest.getInstance(HASH_ALGORITHMS.get(algorithm));
-            md.update(text);
-            return md.digest();
-        } catch (final NoSuchAlgorithmException e) {
-            throw new IllegalArgumentException(e.getMessage(), e);
-        }
+    private boolean checkSignature(
+            final PublicKey publicKey, final byte[] signatureToCheck,
+            final byte[] originalDigest, final String algName) throws Exception {
+        final Signature sig = Signature.getInstance(algName, new BouncyCastleProvider());
+        sig.initVerify(publicKey);
+        sig.update(originalDigest);
+        return sig.verify(signatureToCheck);
     }
 }

--- a/lowkey-vault-testcontainers/src/main/java/com/github/nagyesta/lowkeyvault/testcontainers/LowkeyVaultContainerBuilder.java
+++ b/lowkey-vault-testcontainers/src/main/java/com/github/nagyesta/lowkeyvault/testcontainers/LowkeyVaultContainerBuilder.java
@@ -40,9 +40,6 @@ public final class LowkeyVaultContainerBuilder {
         if (vaultNames == null) {
             throw new IllegalArgumentException("Vault names collection cannot be null.");
         }
-        if (vaultNames.contains(null)) {
-            throw new IllegalArgumentException("Vault names collection cannot contain null.");
-        }
         this.vaultNames = Set.copyOf(vaultNames);
         return this;
     }

--- a/lowkey-vault-testcontainers/src/test/java/com/github/nagyesta/lowkeyvault/testcontainers/LowkeyVaultContainerVanillaTest.java
+++ b/lowkey-vault-testcontainers/src/test/java/com/github/nagyesta/lowkeyvault/testcontainers/LowkeyVaultContainerVanillaTest.java
@@ -34,7 +34,6 @@ class LowkeyVaultContainerVanillaTest extends AbstractLowkeyVaultContainerTest {
     public static Stream<Arguments> invalidDataProvider() {
         return Stream.<Arguments>builder()
                 .add(Arguments.of((Collection<String>) null))
-                .add(Arguments.of(Collections.singleton(null)))
                 .add(Arguments.of(Collections.singleton("")))
                 .add(Arguments.of(Collections.singleton(" ")))
                 .add(Arguments.of(Collections.singleton("- -")))


### PR DESCRIPTION
__Issue:__ #651 <!-- #issue number -->

### Description
<!-- A short summary of changes -->

- Fixes a NPE in case the Testcontainers module receives an immutable set of vault names
- Fixes RSA signature and verification algorithms (allowing the client to do hashing)
- Changes EC signature and verification logic to use BC provider
- Simplifies signature and verification implementation by extracting common parts
- Adds additional validation steps to verify digest length based on the accepted hashes when signature and verification are used
- Adds new test cases to make sure correct algorithms are used by sign logic
- Updates tests where necessary

### Entry point
<!-- Where should the reviewer start in order to properly understand the PR? -->

-

### Checklists

- [x] I have rebased my branch
- [x] My commit message is meaningful
- [x] The commit messages use semantic versioning: ```{major}```, ```{minor}``` or ```{patch}```
- [x] The changes are focusing on the issue at hand
- [x] I have maintained or increased test coverage

### Notes

- Might cause test failures in case wrong algorithms or practices were used in the code using Lowkey Vault. This breaking change is getting Lowkey Vault to behave more as the original Azure Key Vault.
<!-- Any additional remarks you may have. -->
