### PR TITLE
Separate config and data import volumes

### DIFF
--- a/lowkey-vault-app/README.md
+++ b/lowkey-vault-app/README.md
@@ -115,3 +115,9 @@ Example:
 ```shell
 java -jar lowkey-vault-app-<version>.jar --LOWKEY_IMPORT_LOCATION=export.json --LOWKEY_IMPORT_TEMPLATE_HOST=127.0.0.1 --LOWKEY_IMPORT_TEMPLATE_PORT=443
 ```
+
+### External configuration
+
+Since Lowkey Vault is a Spring Boot application, the default mechanism for Spring Boot external configuration can work as well. For example,
+if there is a ./config/application.properties file relative to the folder where you are running Lowkey Vault, the contents will be picked up
+automatically. For more information please see [the Spring Boot documentation](https://docs.spring.io/spring-boot/docs/2.1.9.RELEASE/reference/html/boot-features-external-config.html#boot-features-external-config-application-property-files).

--- a/lowkey-vault-docker/README.md
+++ b/lowkey-vault-docker/README.md
@@ -36,6 +36,14 @@ export LOWKEY_ARGS="--server.port=8444"
 docker run --rm --name lowkey -e LOWKEY_ARGS -d -p 8444:8444 nagyesta/lowkey-vault:<version>
 ```
 
+### External configuration
+
+Since Lowkey Vault is a Spring Boot application, the default mechanism for Spring Boot external 
+configuration can work as well. For example, if there is a ./config/application.properties file relative 
+to the folder where the Jar is running, the contents will be picked up automatically. To utilize this, the
+recommended option is to attach a *.properties file to /config/application.properties (path inside the
+container) using a volume.
+
 ## ARM builds
 
 Lowkey Vault offers a multi-arch variant using Buildx. You can find the relevant project [here](https://github.com/nagyesta/lowkey-vault-docker-buildx).

--- a/lowkey-vault-docker/src/docker/Dockerfile
+++ b/lowkey-vault-docker/src/docker/Dockerfile
@@ -2,6 +2,16 @@ FROM eclipse-temurin:11.0.20_8-jre-alpine@sha256:6a7bdc6f82c73a2fa1c95c5fe7465f8
 LABEL maintainer="nagyesta@gmail.com"
 EXPOSE 8443:8443
 ADD lowkey-vault.jar /lowkey-vault.jar
+RUN addgroup -S lowkey && adduser -S lowkey -G lowkey
+RUN chown -R lowkey:lowkey "/lowkey-vault.jar"
+RUN chmod 555 "/lowkey-vault.jar"
 RUN mkdir "/import"
+RUN chown -R lowkey:lowkey "/import"
+RUN chmod 755 "/import"
+RUN mkdir "/config"
+RUN chown -R lowkey:lowkey "/config"
+RUN chmod 555 "/config"
+USER lowkey
+WORKDIR /
 CMD [ "sh", "-c", "ls /" ]
 ENTRYPOINT ["sh", "-c", "java ${JAVA_OPTS} -jar /lowkey-vault.jar ${LOWKEY_ARGS}"]

--- a/lowkey-vault-testcontainers/README.md
+++ b/lowkey-vault-testcontainers/README.md
@@ -94,7 +94,7 @@ class Test {
         final DockerImageName imageName = DockerImageName.parse("nagyesta/lowkey-vault:1.13.0");
         final LowkeyVaultContainer lowkeyVaultContainer = lowkeyVault(imageName)
                 .noAutoRegistration()  
-                .importFile(importFile)
+                .importFile(importFile, BindMode.READ_ONLY)
                 .logicalPort(8443)
                 .logicalHost("127.0.0.1")
                 .hostPort(8443)

--- a/lowkey-vault-testcontainers/build.gradle
+++ b/lowkey-vault-testcontainers/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     }
     testImplementation libs.mockito.core
     testImplementation libs.jupiter
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testImplementation libs.logback.classic
 }
 

--- a/lowkey-vault-testcontainers/src/main/java/com/github/nagyesta/lowkeyvault/testcontainers/LowkeyVaultArgLineBuilder.java
+++ b/lowkey-vault-testcontainers/src/main/java/com/github/nagyesta/lowkeyvault/testcontainers/LowkeyVaultArgLineBuilder.java
@@ -53,7 +53,7 @@ public class LowkeyVaultArgLineBuilder {
 
     public LowkeyVaultArgLineBuilder customSSLCertificate(final File file, final String password, final StoreType type) {
         if (file != null) {
-            args.add("--server.ssl.key-store=/import/cert.store");
+            args.add("--server.ssl.key-store=/config/cert.store");
             args.add("--server.ssl.key-store-type=" + Optional.ofNullable(type).orElse(StoreType.PKCS12).name());
             args.add("--server.ssl.key-store-password=" + Optional.ofNullable(password).orElse(""));
         }

--- a/lowkey-vault-testcontainers/src/main/java/com/github/nagyesta/lowkeyvault/testcontainers/LowkeyVaultContainer.java
+++ b/lowkey-vault-testcontainers/src/main/java/com/github/nagyesta/lowkeyvault/testcontainers/LowkeyVaultContainer.java
@@ -64,13 +64,19 @@ public class LowkeyVaultContainer extends GenericContainer<LowkeyVaultContainer>
         if (containerBuilder.getImportFile() != null) {
             final String absolutePath = containerBuilder.getImportFile().getAbsolutePath();
             logger().info("Using path for import file: '{}'", absolutePath);
-            withFileSystemBind(absolutePath, "/import/vaults.json", BindMode.READ_ONLY);
+            withFileSystemBind(absolutePath, "/import/vaults.json", containerBuilder.getImportFileBindMode());
         }
 
         if (containerBuilder.getCustomSslCertStore() != null) {
             final String absolutePath = containerBuilder.getCustomSslCertStore().getAbsolutePath();
             logger().info("Using path for custom certificate: '{}'", absolutePath);
-            withFileSystemBind(absolutePath, "/import/cert.store", BindMode.READ_ONLY);
+            withFileSystemBind(absolutePath, "/config/cert.store", BindMode.READ_ONLY);
+        }
+
+        if (containerBuilder.getExternalConfigFile() != null) {
+            final String absolutePath = containerBuilder.getExternalConfigFile().getAbsolutePath();
+            logger().info("Using path for external configuration: '{}'", absolutePath);
+            withFileSystemBind(absolutePath, "/config/application.properties", BindMode.READ_ONLY);
         }
 
         final List<String> args = new LowkeyVaultArgLineBuilder()

--- a/lowkey-vault-testcontainers/src/main/java/com/github/nagyesta/lowkeyvault/testcontainers/LowkeyVaultContainerBuilder.java
+++ b/lowkey-vault-testcontainers/src/main/java/com/github/nagyesta/lowkeyvault/testcontainers/LowkeyVaultContainerBuilder.java
@@ -1,5 +1,6 @@
 package com.github.nagyesta.lowkeyvault.testcontainers;
 
+import org.testcontainers.containers.BindMode;
 import org.testcontainers.utility.DockerImageName;
 
 import java.io.File;
@@ -11,6 +12,7 @@ public final class LowkeyVaultContainerBuilder {
     private Set<String> vaultNames = Set.of();
     private Map<String, Set<String>> aliasMap = Map.of();
     private File importFile;
+    private BindMode importFileBindMode;
     private File customSslCertStore;
     private String customSslCertPassword;
     private StoreType customSslCertType;
@@ -19,6 +21,7 @@ public final class LowkeyVaultContainerBuilder {
     private String logicalHost;
     private List<String> additionalArgs = List.of();
     private boolean debug;
+    private File externalConfigFile;
 
     public static LowkeyVaultContainerBuilder lowkeyVault(final DockerImageName dockerImageName) {
         return new LowkeyVaultContainerBuilder(dockerImageName);
@@ -65,10 +68,26 @@ public final class LowkeyVaultContainerBuilder {
     }
 
     public LowkeyVaultContainerBuilder importFile(final File importFile) {
+        return importFile(importFile, BindMode.READ_ONLY);
+    }
+
+    public LowkeyVaultContainerBuilder importFile(final File importFile, final BindMode bindMode) {
         if (importFile == null) {
             throw new IllegalArgumentException("Import file cannot be null.");
         }
         this.importFile = importFile;
+        this.importFileBindMode = bindMode;
+        return this;
+    }
+
+    public LowkeyVaultContainerBuilder externalConfigFile(final File externalConfigFile) {
+        if (externalConfigFile == null) {
+            throw new IllegalArgumentException("External configuration file cannot be null.");
+        }
+        if (!externalConfigFile.getName().endsWith(".properties")) {
+            throw new IllegalArgumentException("External configuration file must be a *.properties file.");
+        }
+        this.externalConfigFile = externalConfigFile;
         return this;
     }
 
@@ -139,8 +158,16 @@ public final class LowkeyVaultContainerBuilder {
         return importFile;
     }
 
+    public BindMode getImportFileBindMode() {
+        return importFileBindMode;
+    }
+
     public File getCustomSslCertStore() {
         return customSslCertStore;
+    }
+
+    public File getExternalConfigFile() {
+        return externalConfigFile;
     }
 
     public String getCustomSslCertPassword() {

--- a/lowkey-vault-testcontainers/src/test/java/com/github/nagyesta/lowkeyvault/testcontainers/LowkeyVaultArgLineBuilderTest.java
+++ b/lowkey-vault-testcontainers/src/test/java/com/github/nagyesta/lowkeyvault/testcontainers/LowkeyVaultArgLineBuilderTest.java
@@ -146,7 +146,7 @@ class LowkeyVaultArgLineBuilderTest {
     void testCustomSslCertificateShouldSetArgumentWhenCalledWithValidFile() {
         //given
         final LowkeyVaultArgLineBuilder underTest = new LowkeyVaultArgLineBuilder();
-        final List<String> expected = List.of("--server.ssl.key-store=/import/cert.store",
+        final List<String> expected = List.of("--server.ssl.key-store=/config/cert.store",
                 "--server.ssl.key-store-type=JKS",
                 "--server.ssl.key-store-password=pass");
 

--- a/lowkey-vault-testcontainers/src/test/resources/config.properties
+++ b/lowkey-vault-testcontainers/src/test/resources/config.properties
@@ -1,0 +1,1 @@
+logging.level.root=INFO


### PR DESCRIPTION
__Issue:__ #667 <!-- #issue number -->

### Description
<!-- A short summary of changes -->

- Fixes an issue causing a Gradle deprecation warning
- Adds user and group to the Docker image
- Adds new folder for external configuration
- Defines ownership and access control for the folders where import and config can be attached
- Adds new method to the Testcontainers module to allow RW attach of import files
- Adds new method to the Testcontainers module to use external configuration properties
- Adds new tests
- Updates documentation

### Entry point
<!-- Where should the reviewer start in order to properly understand the PR? -->

-

### Checklists

- [x] I have rebased my branch
- [x] My commit message is meaningful
- [x] The commit messages use semantic versioning: ```{major}```, ```{minor}``` or ```{patch}```
- [x] The changes are focusing on the issue at hand
- [x] I have maintained or increased test coverage

### Notes

-
<!-- Any additional remarks you may have. -->
