### PR TITLE
Assumed Identity endpoint in Lowkey Vault

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,21 @@ Lowkey Vault is far from supporting all Azure Key Vault features. The list suppo
 
 [https://localhost:8443/api/swagger-ui/index.html](https://localhost:8443/api/swagger-ui/index.html)
 
+### Port mappings (Default)
+
+#### HTTP `:8080`
+
+Only used for simulating Managed Identity Token endpoint `/metadata/identity/oauth2/token?resource=<resource>`. 
+
+> [!TIP]  
+> This endpoint provides the same Managed Identity stub as [Assumed Identity](https://github.com/nagyesta/assumed-identity). If you want to use Lowkey Vault with Managed Identity, this functionality allows you to do so with a single container.  
+
+#### HTTPS `:8443`
+
+- Readiness/Liveness `/ping`
+- Management API 
+- Key Vault APIs
+
 ## Startup parameters
 
 1. Using the `.jar`: [Lowkey Vault App](lowkey-vault-app/README.md).

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/LowkeyVaultApp.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/LowkeyVaultApp.java
@@ -1,7 +1,13 @@
 package com.github.nagyesta.lowkeyvault;
 
+import org.apache.catalina.connector.Connector;
+import org.apache.coyote.http11.Http11NioProtocol;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.web.servlet.server.ServletWebServerFactory;
+import org.springframework.context.annotation.Bean;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
 /**
@@ -12,7 +18,27 @@ import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 @EnableWebMvc
 public class LowkeyVaultApp {
 
+    @Value("${app.token.port}")
+    private int tokenPort;
+
     public static void main(final String[] args) {
         SpringApplication.run(LowkeyVaultApp.class, args);
+    }
+
+    @Bean
+    public ServletWebServerFactory servletContainer() {
+        final TomcatServletWebServerFactory tomcat = new TomcatServletWebServerFactory();
+        tomcat.addAdditionalTomcatConnectors(createTokenConnector());
+        return tomcat;
+    }
+
+    private Connector createTokenConnector() {
+        final Connector connector = new Connector("org.apache.coyote.http11.Http11NioProtocol");
+        final Http11NioProtocol protocol = (Http11NioProtocol) connector.getProtocolHandler();
+        connector.setScheme("http");
+        connector.setSecure(false);
+        connector.setPort(tokenPort);
+        protocol.setSSLEnabled(false);
+        return connector;
     }
 }

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/controller/ManagedIdentityTokenController.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/controller/ManagedIdentityTokenController.java
@@ -1,0 +1,22 @@
+package com.github.nagyesta.lowkeyvault.controller;
+
+import com.github.nagyesta.lowkeyvault.model.TokenResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+
+@Slf4j
+@RestController
+public class ManagedIdentityTokenController {
+
+    @GetMapping(value = {"/metadata/identity/oauth2/token", "/metadata/identity/oauth2/token/"})
+    public ResponseEntity<TokenResponse> get(@RequestParam("resource") final URI resource) {
+        final TokenResponse body = new TokenResponse(resource);
+        log.info("Returning token: {}", body);
+        return ResponseEntity.ok(body);
+    }
+}

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/filter/CommonAuthHeaderFilter.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/filter/CommonAuthHeaderFilter.java
@@ -27,7 +27,7 @@ public class CommonAuthHeaderFilter extends OncePerRequestFilter {
     private static final String HTTPS = "https://";
     private static final String BEARER_FAKE_TOKEN = "Bearer resource=\"%s\", authorization_uri=\"%s\"";
     private final AntPathMatcher antPathMatcher = new AntPathMatcher();
-    private final Set<String> skipUrisIfMatch = Set.of("/ping", "/management/**", "/api/**");
+    private final Set<String> skipUrisIfMatch = Set.of("/ping", "/management/**", "/api/**", "/metadata/**");
 
     @Override
     protected void doFilterInternal(final HttpServletRequest request, final HttpServletResponse response,

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/filter/PortSeparationFilter.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/filter/PortSeparationFilter.java
@@ -1,0 +1,32 @@
+package com.github.nagyesta.lowkeyvault.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@Slf4j
+public class PortSeparationFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(
+            final HttpServletRequest request, final HttpServletResponse response, final FilterChain filterChain)
+            throws ServletException, IOException {
+        final var secure = request.isSecure();
+        final boolean isTokenRequest = "/metadata/identity/oauth2/token".equals(request.getRequestURI());
+        final boolean unsecureTokenRequest = isTokenRequest && !secure;
+        final boolean secureVaultRequest = !isTokenRequest && secure;
+        if (unsecureTokenRequest || secureVaultRequest) {
+            filterChain.doFilter(request, response);
+        } else {
+            response.sendError(HttpServletResponse.SC_NOT_FOUND);
+        }
+    }
+
+}

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/model/TokenResponse.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/model/TokenResponse.java
@@ -1,0 +1,26 @@
+package com.github.nagyesta.lowkeyvault.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+import lombok.NonNull;
+import org.springframework.util.Assert;
+
+import java.net.URI;
+import java.time.Instant;
+
+public record TokenResponse(
+        @NonNull @JsonProperty("resource") URI resource,
+        @NonNull @JsonProperty("access_token") String accessToken,
+        @NonNull @JsonProperty("refresh_token") String refreshToken,
+        @JsonProperty("expires_in") long expiresIn,
+        @JsonProperty("expires_on") long expiresOn,
+        @JsonProperty("tokenType") int tokenType) {
+
+    private static final long EXPIRES_IN = 48 * 3600L;
+    private static final String TOKEN = "dummy";
+
+    public TokenResponse(@NotNull final URI resource) {
+        this(resource, TOKEN, TOKEN, EXPIRES_IN, Instant.now().plusSeconds(EXPIRES_IN).getEpochSecond(), 1);
+        Assert.hasText(resource.toString(), "Resource must not be empty");
+    }
+}

--- a/lowkey-vault-app/src/main/resources/application.properties
+++ b/lowkey-vault-app/src/main/resources/application.properties
@@ -5,6 +5,7 @@ application.formatted-version=\\ (v${version})
 # suppress inspection "SpringBootApplicationProperties"
 application.title=Lowkey Vault
 #
+app.token.port=8080
 server.port=8443
 server.ssl.ciphers=TLS_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
 server.ssl.protocol=TLS

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/controller/common/TokenControllerTest.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/controller/common/TokenControllerTest.java
@@ -1,0 +1,30 @@
+package com.github.nagyesta.lowkeyvault.controller.common;
+
+import com.github.nagyesta.lowkeyvault.controller.ManagedIdentityTokenController;
+import com.github.nagyesta.lowkeyvault.model.TokenResponse;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.net.URI;
+
+class TokenControllerTest {
+
+    @Test
+    void testGetShouldReturnTokenWhenCalled() {
+        //given
+        final ManagedIdentityTokenController underTest = new ManagedIdentityTokenController();
+        final URI resource = URI.create("https://localhost:8443/");
+
+        //when
+        final ResponseEntity<TokenResponse> actual = underTest.get(resource);
+
+        //then
+        Assertions.assertNotNull(actual);
+        Assertions.assertEquals(HttpStatus.OK, actual.getStatusCode());
+        Assertions.assertNotNull(actual.getBody());
+        Assertions.assertEquals(resource, actual.getBody().resource());
+        Assertions.assertEquals("dummy", actual.getBody().accessToken());
+    }
+}

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/filter/PortSeparationFilterTest.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/filter/PortSeparationFilterTest.java
@@ -1,0 +1,83 @@
+package com.github.nagyesta.lowkeyvault.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.*;
+
+class PortSeparationFilterTest {
+
+    @Test
+    void testDoFilterInternalShouldCallChainWhenInsecureAndTokenRequest() throws ServletException, IOException {
+        //given
+        final PortSeparationFilter underTest = new PortSeparationFilter();
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        final HttpServletResponse response = mock(HttpServletResponse.class);
+        final FilterChain chain = mock(FilterChain.class);
+        when(request.isSecure()).thenReturn(false);
+        when(request.getRequestURI()).thenReturn("/metadata/identity/oauth2/token");
+
+        //when
+        underTest.doFilterInternal(request, response, chain);
+
+        //then
+        verify(chain).doFilter(same(request), same(response));
+    }
+
+    @Test
+    void testDoFilterInternalShouldCallChainWhenSecureAndNotTokenRequest() throws ServletException, IOException {
+        //given
+        final PortSeparationFilter underTest = new PortSeparationFilter();
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        final HttpServletResponse response = mock(HttpServletResponse.class);
+        final FilterChain chain = mock(FilterChain.class);
+        when(request.isSecure()).thenReturn(true);
+        when(request.getRequestURI()).thenReturn("/ping");
+
+        //when
+        underTest.doFilterInternal(request, response, chain);
+
+        //then
+        verify(chain).doFilter(same(request), same(response));
+    }
+
+    @Test
+    void testDoFilterInternalShouldReturnNotFoundWhenSecureAndTokenRequest() throws ServletException, IOException {
+        //given
+        final PortSeparationFilter underTest = new PortSeparationFilter();
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        final HttpServletResponse response = mock(HttpServletResponse.class);
+        final FilterChain chain = mock(FilterChain.class);
+        when(request.isSecure()).thenReturn(true);
+        when(request.getRequestURI()).thenReturn("/metadata/identity/oauth2/token");
+
+        //when
+        underTest.doFilterInternal(request, response, chain);
+
+        //then
+        verify(response).sendError(HttpServletResponse.SC_NOT_FOUND);
+    }
+
+    @Test
+    void testDoFilterInternalShouldReturnNotFoundWhenInsecureAndNotTokenRequest() throws ServletException, IOException {
+        //given
+        final PortSeparationFilter underTest = new PortSeparationFilter();
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        final HttpServletResponse response = mock(HttpServletResponse.class);
+        final FilterChain chain = mock(FilterChain.class);
+        when(request.isSecure()).thenReturn(false);
+        when(request.getRequestURI()).thenReturn("/ping");
+
+        //when
+        underTest.doFilterInternal(request, response, chain);
+
+        //then
+        verify(response).sendError(HttpServletResponse.SC_NOT_FOUND);
+    }
+}

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/model/TokenResponseTest.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/model/TokenResponseTest.java
@@ -1,0 +1,85 @@
+package com.github.nagyesta.lowkeyvault.model;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.net.URI;
+import java.time.Instant;
+import java.util.stream.Stream;
+
+class TokenResponseTest {
+
+    private static final int EXPECTED_EXPIRY = 48 * 3600;
+    private static final long MIN_EXPIRES_ON = Instant.now().plusSeconds(EXPECTED_EXPIRY).getEpochSecond();
+    private static final int TOKEN_TYPE = 1;
+    private static final String DUMMY_TOKEN = "dummy";
+    private static final URI RESOURCE = URI.create("https://localhost:8443/path");
+
+    public static Stream<Arguments> nullValuesProvider() {
+        final URI resource = RESOURCE;
+        final String token = DUMMY_TOKEN;
+        final long expiresIn = EXPECTED_EXPIRY;
+        final long expiresOn = MIN_EXPIRES_ON;
+        final int tokenType = TOKEN_TYPE;
+
+        return Stream.of(
+                Arguments.of(null, token, token, expiresIn, expiresOn, tokenType),
+                Arguments.of(resource, null, token, expiresIn, expiresOn, tokenType),
+                Arguments.of(resource, token, null, expiresIn, expiresOn, tokenType)
+        );
+    }
+
+    @Test
+    void testConstructorShouldThrowExceptionWhenCalledWithNull() {
+        //given
+
+        //when
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new TokenResponse(null));
+
+        //then + expected
+    }
+
+    @Test
+    void testConstructorShouldThrowExceptionWhenCalledWithEmptyResource() {
+        //given
+        final URI resource = URI.create("");
+
+        //when
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new TokenResponse(resource));
+
+        //then + expected
+    }
+
+    @ParameterizedTest
+    @MethodSource("nullValuesProvider")
+    void testConstructorShouldThrowExceptionWhenCalledWithNulls(
+            final URI resource, final String accessToken, final String refreshToken,
+            final long expiresIn, final long expiresOn, final int tokenType) {
+        //given
+
+        //when
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> new TokenResponse(resource, accessToken, refreshToken, expiresIn, expiresOn, tokenType));
+
+        //then + expected
+    }
+
+    @Test
+    void testConstructorShouldReturnNonExpiredTokenValidForTheProvidedResourceWhenCalledWithValidResource() {
+        //given
+
+        //when
+        final TokenResponse actual = new TokenResponse(RESOURCE);
+
+        //then
+        Assertions.assertEquals(RESOURCE, actual.resource());
+        Assertions.assertEquals(DUMMY_TOKEN, actual.accessToken());
+        Assertions.assertEquals(DUMMY_TOKEN, actual.refreshToken());
+        Assertions.assertEquals(EXPECTED_EXPIRY, actual.expiresIn());
+        Assertions.assertTrue(MIN_EXPIRES_ON <= actual.expiresOn());
+        Assertions.assertEquals(TOKEN_TYPE, actual.tokenType());
+    }
+}

--- a/lowkey-vault-app/src/test/resources/test-application.properties
+++ b/lowkey-vault-app/src/test/resources/test-application.properties
@@ -1,1 +1,2 @@
 LOWKEY_DEBUG_REQUEST_LOG=true
+app.token.port=8080

--- a/lowkey-vault-docker/README.md
+++ b/lowkey-vault-docker/README.md
@@ -36,6 +36,19 @@ export LOWKEY_ARGS="--server.port=8444"
 docker run --rm --name lowkey -e LOWKEY_ARGS -d -p 8444:8444 nagyesta/lowkey-vault:<version>
 ```
 
+### Using simulated Managed Identity
+
+In case you want to rely on the built-in simulated Managed Identity token endpoint, you must make sure 
+to forward the relevant `8080` HTTP only port as well. The host port you are using can be anything you
+would like to use in this case. This will make the `/metadata/identity/oauth2/token` endpoint available. 
+Please check the [example projects](../README.md#example-projects) to see how you can use the provided 
+endpoint.
+
+```shell
+docker run --rm --name lowkey -d -p 8080:8080 -p 8444:8444 nagyesta/lowkey-vault:<version>
+```
+
+
 ### External configuration
 
 Since Lowkey Vault is a Spring Boot application, the default mechanism for Spring Boot external 

--- a/lowkey-vault-docker/src/docker/Dockerfile
+++ b/lowkey-vault-docker/src/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM eclipse-temurin:17.0.11_9-jre-alpine@sha256:ad9223070abcf5716e98296a98c371368810deb36197b75f3a7b74815185c5e3
 LABEL maintainer="nagyesta@gmail.com"
-EXPOSE 8443:8443
+EXPOSE 8080 8443
 ADD lowkey-vault.jar /lowkey-vault.jar
 RUN \
   addgroup -S lowkey && adduser -S lowkey -G lowkey && \

--- a/lowkey-vault-testcontainers/README.md
+++ b/lowkey-vault-testcontainers/README.md
@@ -91,7 +91,7 @@ import static com.github.nagyesta.lowkeyvault.testcontainers.LowkeyVaultContaine
 class Test {
     public LowkeyVaultContainer startVault(final File importFile) {
         //Please consider using latest image regardless of the value in the example
-        final DockerImageName imageName = DockerImageName.parse("nagyesta/lowkey-vault:1.13.0");
+        final DockerImageName imageName = DockerImageName.parse("nagyesta/lowkey-vault:<version>");
         final LowkeyVaultContainer lowkeyVaultContainer = lowkeyVault(imageName)
                 .noAutoRegistration()  
                 .importFile(importFile, BindMode.READ_ONLY)
@@ -119,7 +119,7 @@ import static com.github.nagyesta.lowkeyvault.testcontainers.LowkeyVaultContaine
 class Test {
     public LowkeyVaultContainer startVault(final File certFile) {
         //Please consider using latest image regardless of the value in the example
-        final DockerImageName imageName = DockerImageName.parse("nagyesta/lowkey-vault:1.13.0");
+        final DockerImageName imageName = DockerImageName.parse("nagyesta/lowkey-vault:<version>");
         final LowkeyVaultContainer lowkeyVaultContainer = lowkeyVault(imageName)
                 .noAutoRegistration()
                 .customSslCertificate(certFile, "password", StoreType.JKS)
@@ -145,7 +145,7 @@ import static com.github.nagyesta.lowkeyvault.testcontainers.LowkeyVaultContaine
 class Test {
     public LowkeyVaultContainer startVault() {
         //Please consider using latest image regardless of the value in the example
-        final DockerImageName imageName = DockerImageName.parse("nagyesta/lowkey-vault:1.13.0");
+        final DockerImageName imageName = DockerImageName.parse("nagyesta/lowkey-vault:<version>");
         final LowkeyVaultContainer lowkeyVaultContainer = lowkeyVault(imageName)
                 .additionalArgs(List.of("--logging.level.root=INFO"))
                 .build()
@@ -170,7 +170,7 @@ import static com.github.nagyesta.lowkeyvault.testcontainers.LowkeyVaultContaine
 class Test {
     public LowkeyVaultContainer startVault() {
         //Please consider using latest image regardless of the value in the example
-        final DockerImageName imageName = DockerImageName.parse("nagyesta/lowkey-vault:1.13.0");
+        final DockerImageName imageName = DockerImageName.parse("nagyesta/lowkey-vault:<version>");
         final LowkeyVaultContainer lowkeyVaultContainer = lowkeyVault(imageName)
                 .vaultAliases(Map.of("localhost", Set.of("alias1", "alias2:8443")))
                 .build()

--- a/lowkey-vault-testcontainers/src/main/java/com/github/nagyesta/lowkeyvault/testcontainers/LowkeyVaultContainer.java
+++ b/lowkey-vault-testcontainers/src/main/java/com/github/nagyesta/lowkeyvault/testcontainers/LowkeyVaultContainer.java
@@ -18,10 +18,14 @@ public class LowkeyVaultContainer extends GenericContainer<LowkeyVaultContainer>
     private static final String DUMMY_USERNAME = "DUMMY";
     private static final String DUMMY_PASSWORD = "DUMMY";
     private static final int CONTAINER_PORT = 8443;
+    private static final int CONTAINER_TOKEN_PORT = 8080;
+    @SuppressWarnings("HttpUrlsUsage")
+    private static final String HTTP = "http://";
     private static final String HTTPS = "https://";
     private static final String PORT_SEPARATOR = ":";
     private static final String LOCALHOST = "localhost";
     private static final String DOT = ".";
+    private static final String TOKEN_ENDPOINT_PATH = "/metadata/identity/oauth2/token";
 
     /**
      * Creates a new instance.
@@ -59,6 +63,11 @@ public class LowkeyVaultContainer extends GenericContainer<LowkeyVaultContainer>
             addFixedExposedPort(containerBuilder.getHostPort(), CONTAINER_PORT);
         } else {
             addExposedPort(CONTAINER_PORT);
+        }
+        if (containerBuilder.getHostTokenPort() != null) {
+            addFixedExposedPort(containerBuilder.getHostTokenPort(), CONTAINER_TOKEN_PORT);
+        } else {
+            addExposedPort(CONTAINER_TOKEN_PORT);
         }
 
         if (containerBuilder.getImportFile() != null) {
@@ -107,6 +116,23 @@ public class LowkeyVaultContainer extends GenericContainer<LowkeyVaultContainer>
         return HTTPS + getDefaultVaultAuthority();
     }
 
+    /**
+     * Returns the URL of the token endpoint.
+     *
+     * @return token endpoint base URL.
+     */
+    public String getTokenEndpointBaseUrl() {
+        return HTTP + LOCALHOST + PORT_SEPARATOR + getMappedPort(CONTAINER_TOKEN_PORT);
+    }
+
+    /**
+     * Returns the full URL of the token endpoint.
+     *
+     * @return full token endpoint URL.
+     */
+    public String getTokenEndpointUrl() {
+        return getTokenEndpointBaseUrl() + TOKEN_ENDPOINT_PATH;
+    }
 
     /**
      * Returns the URL of the vault with a given name.

--- a/lowkey-vault-testcontainers/src/main/java/com/github/nagyesta/lowkeyvault/testcontainers/LowkeyVaultContainerBuilder.java
+++ b/lowkey-vault-testcontainers/src/main/java/com/github/nagyesta/lowkeyvault/testcontainers/LowkeyVaultContainerBuilder.java
@@ -17,6 +17,7 @@ public final class LowkeyVaultContainerBuilder {
     private String customSslCertPassword;
     private StoreType customSslCertType;
     private Integer hostPort;
+    private Integer hostTokenPort;
     private Integer logicalPort;
     private String logicalHost;
     private List<String> additionalArgs = List.of();
@@ -109,6 +110,14 @@ public final class LowkeyVaultContainerBuilder {
         return this;
     }
 
+    public LowkeyVaultContainerBuilder hostTokenPort(final int hostTokenPort) {
+        if (hostTokenPort < 1) {
+            throw new IllegalArgumentException("Host token port cannot be zero or negative.");
+        }
+        this.hostTokenPort = hostTokenPort;
+        return this;
+    }
+
     public LowkeyVaultContainerBuilder logicalPort(final int logicalPort) {
         if (logicalPort < 1) {
             throw new IllegalArgumentException("Logical port cannot be zero or negative.");
@@ -180,6 +189,10 @@ public final class LowkeyVaultContainerBuilder {
 
     public Integer getHostPort() {
         return hostPort;
+    }
+
+    public Integer getHostTokenPort() {
+        return hostTokenPort;
     }
 
     public Integer getLogicalPort() {

--- a/lowkey-vault-testcontainers/src/test/java/com/github/nagyesta/lowkeyvault/testcontainers/AbstractLowkeyVaultContainerTest.java
+++ b/lowkey-vault-testcontainers/src/test/java/com/github/nagyesta/lowkeyvault/testcontainers/AbstractLowkeyVaultContainerTest.java
@@ -2,6 +2,8 @@ package com.github.nagyesta.lowkeyvault.testcontainers;
 
 import com.azure.core.credential.TokenCredential;
 import com.azure.core.http.HttpClient;
+import com.azure.core.http.HttpMethod;
+import com.azure.core.http.HttpRequest;
 import com.azure.core.http.policy.FixedDelay;
 import com.azure.core.http.policy.RetryPolicy;
 import com.azure.security.keyvault.secrets.SecretClient;
@@ -16,6 +18,7 @@ public class AbstractLowkeyVaultContainerTest {
 
     private static final String NAME = "name";
     private static final String VALUE = "value";
+    private static final int SUCCESS = 200;
 
     protected String getCurrentLowkeyVaultImageName() {
         return "lowkey-vault:" + System.getProperty("imageVersion");
@@ -34,5 +37,13 @@ public class AbstractLowkeyVaultContainerTest {
         final KeyVaultSecret secret = secretClient.setSecret(NAME, VALUE);
 
         Assertions.assertNotNull(secret);
+    }
+
+    protected void verifyTokenEndpointIsWorking(final String endpointUrl, final HttpClient httpClient) {
+        httpClient.send(new HttpRequest(HttpMethod.GET, endpointUrl + "?resource=https://localhost"))
+                .doOnError(Assertions::fail)
+                .doOnSuccess(response -> Assertions.assertEquals(SUCCESS, response.getStatusCode()))
+                .single()
+                .block();
     }
 }

--- a/lowkey-vault-testcontainers/src/test/java/com/github/nagyesta/lowkeyvault/testcontainers/LowkeyVaultContainerJupiterTest.java
+++ b/lowkey-vault-testcontainers/src/test/java/com/github/nagyesta/lowkeyvault/testcontainers/LowkeyVaultContainerJupiterTest.java
@@ -15,6 +15,7 @@ import org.testcontainers.utility.DockerImageName;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 
 import static com.github.nagyesta.lowkeyvault.testcontainers.LowkeyVaultContainerBuilder.lowkeyVault;
 
@@ -60,5 +61,16 @@ class LowkeyVaultContainerJupiterTest extends AbstractLowkeyVaultContainerTest {
         final ApacheHttpClient httpClient = new ApacheHttpClient(authorityOverrideFunction,
                 new TrustSelfSignedStrategy(), new DefaultHostnameVerifier());
         verifyConnectionIsWorking(endpoint, httpClient, credentials);
+    }
+
+    @Test
+    void testContainerShouldProvideTokenEndpointWhenCalledWithValidParameters() {
+        //given + when test container is created
+
+        //then
+        final String endpoint = underTest.getTokenEndpointUrl();
+        final ApacheHttpClient httpClient = new ApacheHttpClient(Function.identity(),
+                new TrustSelfSignedStrategy(), new DefaultHostnameVerifier());
+        verifyTokenEndpointIsWorking(endpoint, httpClient);
     }
 }


### PR DESCRIPTION
__Issue:__ #960

### Description
<!-- A short summary of changes -->

- Adds configuration to listen to the 8080 HTTP port for token requests
- Adds new ManagedIdentityTokenController to handle token requests
- Adds filter to enforce functional separation between the 8080 and 8443 ports
- Extends Testcontainers support with token endpoint related configuration
- Adds new tests
- Updates documentation

### Entry point
<!-- Where should the reviewer start in order to properly understand the PR? -->

-

### Checklists

- [x] I have rebased my branch
- [x] My commit message is meaningful
- [x] The commit messages use semantic versioning: ```{major}```, ```{minor}``` or ```{patch}```
- [x] The changes are focusing on the issue at hand
- [x] I have maintained or increased test coverage

### Notes

-
<!-- Any additional remarks you may have. -->
