### PR TITLE
Bug: Management endpoints require Content-Type header even if no request body needed

### DIFF
--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/controller/VaultBackupManagementController.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/controller/VaultBackupManagementController.java
@@ -10,7 +10,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
@@ -26,9 +25,7 @@ import java.util.List;
 
 @Slf4j
 @RestController
-@RequestMapping(value = "/management/vault",
-        consumes = MimeTypeUtils.APPLICATION_JSON_VALUE,
-        produces = MimeTypeUtils.APPLICATION_JSON_VALUE)
+@RequestMapping(value = "/management/vault", produces = MimeTypeUtils.APPLICATION_JSON_VALUE)
 public class VaultBackupManagementController extends ErrorHandlingAwareController implements InitializingBean {
 
     private final VaultImporter vaultImporter;
@@ -60,9 +57,8 @@ public class VaultBackupManagementController extends ErrorHandlingAwareControlle
                             content = @Content(
                                     mediaType = MimeTypeUtils.APPLICATION_JSON_VALUE,
                                     schema = @Schema(implementation = ErrorModel.class)
-                            ))},
-            requestBody = @RequestBody(content = @Content(mediaType = MimeTypeUtils.APPLICATION_JSON_VALUE)))
-    @GetMapping(value = {"/export", "/export/"})
+                            ))})
+    @GetMapping(value = {"/export", "/export/"}, produces = MimeTypeUtils.APPLICATION_JSON_VALUE)
     public ResponseEntity<VaultBackupListModel> export() {
         log.info("Received request to export active vaults.");
         final List<VaultBackupModel> backupModels = vaultImportExportExecutor.backupVaultList(vaultService);

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/controller/VaultManagementController.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/controller/VaultManagementController.java
@@ -27,9 +27,7 @@ import static org.springframework.util.MimeTypeUtils.APPLICATION_JSON_VALUE;
 
 @Slf4j
 @RestController
-@RequestMapping(value = "/management/vault",
-        consumes = APPLICATION_JSON_VALUE,
-        produces = APPLICATION_JSON_VALUE)
+@RequestMapping(value = "/management/vault", produces = APPLICATION_JSON_VALUE)
 public class VaultManagementController extends ErrorHandlingAwareController {
 
     private final VaultService vaultService;
@@ -56,7 +54,7 @@ public class VaultManagementController extends ErrorHandlingAwareController {
                             content = @Content(mediaType = APPLICATION_JSON_VALUE, schema = @Schema(implementation = ErrorModel.class)))},
             requestBody = @RequestBody(
                     content = @Content(mediaType = APPLICATION_JSON_VALUE, schema = @Schema(implementation = VaultModel.class))))
-    @PostMapping(value = {"", "/"})
+    @PostMapping(value = {"", "/"}, consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<VaultModel> createVault(@Valid @org.springframework.web.bind.annotation.RequestBody final VaultModel model) {
         log.info("Received request to create vault with uri: {}, recovery level: {}, recoverable days: {}",
                 model.getBaseUri(), model.getRecoveryLevel(), model.getRecoverableDays());
@@ -72,9 +70,8 @@ public class VaultManagementController extends ErrorHandlingAwareController {
                             content = @Content(mediaType = APPLICATION_JSON_VALUE,
                                     array = @ArraySchema(schema = @Schema(implementation = VaultModel.class)))),
                     @ApiResponse(responseCode = "500", description = "Internal error",
-                            content = @Content(mediaType = APPLICATION_JSON_VALUE, schema = @Schema(implementation = ErrorModel.class)))},
-            requestBody = @RequestBody(content = @Content(mediaType = APPLICATION_JSON_VALUE)))
-    @GetMapping(value = {"", "/"})
+                            content = @Content(mediaType = APPLICATION_JSON_VALUE, schema = @Schema(implementation = ErrorModel.class)))})
+    @GetMapping(value = {"", "/"}, produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<List<VaultModel>> listVaults() {
         log.info("Received request to list vaults.");
         final List<VaultModel> vaultFake = vaultService.list().stream()
@@ -91,9 +88,8 @@ public class VaultManagementController extends ErrorHandlingAwareController {
                             content = @Content(mediaType = APPLICATION_JSON_VALUE,
                                     array = @ArraySchema(schema = @Schema(implementation = VaultModel.class)))),
                     @ApiResponse(responseCode = "500", description = "Internal error",
-                            content = @Content(mediaType = APPLICATION_JSON_VALUE, schema = @Schema(implementation = ErrorModel.class)))},
-            requestBody = @RequestBody(content = @Content(mediaType = APPLICATION_JSON_VALUE)))
-    @GetMapping(value = {"/deleted", "/deleted/"})
+                            content = @Content(mediaType = APPLICATION_JSON_VALUE, schema = @Schema(implementation = ErrorModel.class)))})
+    @GetMapping(value = {"/deleted", "/deleted/"}, produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<List<VaultModel>> listDeletedVaults() {
         log.info("Received request to list deleted vaults.");
         final List<VaultModel> vaultFake = vaultService.listDeleted().stream()
@@ -117,9 +113,8 @@ public class VaultManagementController extends ErrorHandlingAwareController {
                             content = @Content(mediaType = APPLICATION_JSON_VALUE, schema = @Schema(implementation = ErrorModel.class)))},
             parameters = {
                     @Parameter(name = "baseUri",
-                            example = BASE_URI, description = "The base URI of the vault we want delete.", required = true)},
-            requestBody = @RequestBody(content = @Content(mediaType = APPLICATION_JSON_VALUE)))
-    @DeleteMapping(value = {"", "/"})
+                            example = BASE_URI, description = "The base URI of the vault we want delete.", required = true)})
+    @DeleteMapping(value = {"", "/"}, produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<Boolean> deleteVault(@RequestParam final URI baseUri) {
         log.info("Received request to delete vault with uri: {}", baseUri);
         return ResponseEntity.ok(vaultService.delete(baseUri));
@@ -140,7 +135,7 @@ public class VaultManagementController extends ErrorHandlingAwareController {
                     @Parameter(name = "baseUri",
                             example = BASE_URI, description = "The base URI of the vault we want to recover.", required = true)},
             requestBody = @RequestBody(content = @Content(mediaType = APPLICATION_JSON_VALUE)))
-    @PutMapping(value = {"/recover", "/recover/"})
+    @PutMapping(value = {"/recover", "/recover/"}, consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<VaultModel> recoverVault(@RequestParam final URI baseUri) {
         log.info("Received request to recover deleted vault with uri: {}", baseUri);
         vaultService.recover(baseUri);
@@ -162,9 +157,8 @@ public class VaultManagementController extends ErrorHandlingAwareController {
                             content = @Content(mediaType = APPLICATION_JSON_VALUE, schema = @Schema(implementation = ErrorModel.class)))},
             parameters = {
                     @Parameter(name = "baseUri",
-                            example = BASE_URI, description = "The base URI of the vault we want to purge.", required = true)},
-            requestBody = @RequestBody(content = @Content(mediaType = APPLICATION_JSON_VALUE)))
-    @DeleteMapping(value = {"/purge", "/purge/"})
+                            example = BASE_URI, description = "The base URI of the vault we want to purge.", required = true)})
+    @DeleteMapping(value = {"/purge", "/purge/"}, produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<Boolean> purgeVault(@RequestParam final URI baseUri) {
         log.info("Received request to purge deleted vault with uri: {}", baseUri);
         return ResponseEntity.ok(vaultService.purge(baseUri));
@@ -189,7 +183,7 @@ public class VaultManagementController extends ErrorHandlingAwareController {
                     @Parameter(name = "remove", example = ALIAS2,
                             description = "The base URI we want to remove from the aliases of the vault.")},
             requestBody = @RequestBody(content = @Content(mediaType = APPLICATION_JSON_VALUE)))
-    @PatchMapping(value = {"/alias", "/alias/"})
+    @PatchMapping(value = {"/alias", "/alias/"}, consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<VaultModel> aliasUpdate(@RequestParam final URI baseUri,
                                                   @RequestParam(required = false) final URI add,
                                                   @RequestParam(required = false) final URI remove) {
@@ -212,7 +206,8 @@ public class VaultManagementController extends ErrorHandlingAwareController {
                     @Parameter(name = "regenerateCertificates", example = FALSE,
                             description = "Whether we allow regeneration of certificates to let their validity match the new time-frame.")},
             requestBody = @RequestBody(content = @Content(mediaType = APPLICATION_JSON_VALUE)))
-    @PutMapping(value = {"/time/all", "/time/all/"}, params = {"seconds"})
+    @PutMapping(value = {"/time/all", "/time/all/"}, params = {"seconds"},
+            consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<Void> timeShiftAll(
             @RequestParam final int seconds,
             @RequestParam(required = false, defaultValue = "false") final boolean regenerateCertificates) {
@@ -240,7 +235,8 @@ public class VaultManagementController extends ErrorHandlingAwareController {
                     @Parameter(name = "regenerateCertificates", example = FALSE,
                             description = "Whether we allow regeneration of certificates to let their validity match the new time-frame.")},
             requestBody = @RequestBody(content = @Content(mediaType = APPLICATION_JSON_VALUE)))
-    @PutMapping(value = {"/time", "/time/" }, params = {"baseUri", "seconds"})
+    @PutMapping(value = {"/time", "/time/"}, params = {"baseUri", "seconds"},
+            consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<Void> timeShiftSingle(
             @RequestParam final URI baseUri, @RequestParam final int seconds,
             @RequestParam(required = false, defaultValue = "false") final boolean regenerateCertificates) {

--- a/lowkey-vault-client/src/main/java/com/github/nagyesta/lowkeyvault/http/management/impl/LowkeyVaultManagementClientImpl.java
+++ b/lowkey-vault-client/src/main/java/com/github/nagyesta/lowkeyvault/http/management/impl/LowkeyVaultManagementClientImpl.java
@@ -1,9 +1,6 @@
 package com.github.nagyesta.lowkeyvault.http.management.impl;
 
-import com.azure.core.http.HttpClient;
-import com.azure.core.http.HttpMethod;
-import com.azure.core.http.HttpRequest;
-import com.azure.core.http.HttpResponse;
+import com.azure.core.http.*;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
@@ -11,7 +8,6 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 import com.github.nagyesta.lowkeyvault.http.management.*;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.http.HttpHeaders;
 import reactor.util.annotation.Nullable;
 
 import java.io.ByteArrayInputStream;
@@ -81,31 +77,28 @@ public final class LowkeyVaultManagementClientImpl implements LowkeyVaultManagem
         final URI uri = UriUtil.uriBuilderForPath(vaultUrl, MANAGEMENT_VAULT_PATH);
         final HttpRequest request = new HttpRequest(HttpMethod.POST, uri.toString())
                 .setBody(body)
-                .setHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON);
+                .setHeader(HttpHeaderName.CONTENT_TYPE, APPLICATION_JSON);
         return sendAndProcess(request, r -> r.getResponseObject(VaultModel.class));
     }
 
     @Override
     public List<VaultModel> listVaults() {
         final URI uri = UriUtil.uriBuilderForPath(vaultUrl, MANAGEMENT_VAULT_PATH);
-        final HttpRequest request = new HttpRequest(HttpMethod.GET, uri.toString())
-                .setHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON);
+        final HttpRequest request = new HttpRequest(HttpMethod.GET, uri.toString());
         return sendAndProcess(request, r -> r.getResponseObject(VAULT_MODEL_LIST_TYPE_REF));
     }
 
     @Override
     public List<VaultModel> listDeletedVaults() {
         final URI uri = UriUtil.uriBuilderForPath(vaultUrl, MANAGEMENT_VAULT_DELETED_PATH);
-        final HttpRequest request = new HttpRequest(HttpMethod.GET, uri.toString())
-                .setHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON);
+        final HttpRequest request = new HttpRequest(HttpMethod.GET, uri.toString());
         return sendAndProcess(request, r -> r.getResponseObject(VAULT_MODEL_LIST_TYPE_REF));
     }
 
     @Override
     public boolean delete(@NonNull final URI baseUri) {
         final URI uri = UriUtil.uriBuilderForPath(vaultUrl, MANAGEMENT_VAULT_PATH, Map.of(BASE_URI_QUERY_PARAM, baseUri.toString()));
-        final HttpRequest request = new HttpRequest(HttpMethod.DELETE, uri.toString())
-                .setHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON);
+        final HttpRequest request = new HttpRequest(HttpMethod.DELETE, uri.toString());
         return sendAndProcess(request, r -> r.getResponseObject(Boolean.class));
     }
 
@@ -114,7 +107,7 @@ public final class LowkeyVaultManagementClientImpl implements LowkeyVaultManagem
         final Map<String, String> parameters = Map.of(BASE_URI_QUERY_PARAM, baseUri.toString());
         final URI uri = UriUtil.uriBuilderForPath(vaultUrl, MANAGEMENT_VAULT_RECOVERY_PATH, parameters);
         final HttpRequest request = new HttpRequest(HttpMethod.PUT, uri.toString())
-                .setHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON);
+                .setHeader(HttpHeaderName.CONTENT_TYPE, APPLICATION_JSON);
         return sendAndProcess(request, r -> r.getResponseObject(VaultModel.class));
     }
 
@@ -136,8 +129,7 @@ public final class LowkeyVaultManagementClientImpl implements LowkeyVaultManagem
     public boolean purge(@NonNull final URI baseUri) {
         final Map<String, String> parameters = Map.of(BASE_URI_QUERY_PARAM, baseUri.toString());
         final URI uri = UriUtil.uriBuilderForPath(vaultUrl, MANAGEMENT_VAULT_PURGE_PATH, parameters);
-        final HttpRequest request = new HttpRequest(HttpMethod.DELETE, uri.toString())
-                .setHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON);
+        final HttpRequest request = new HttpRequest(HttpMethod.DELETE, uri.toString());
         return sendAndProcess(request, r -> r.getResponseObject(Boolean.class));
     }
 
@@ -153,15 +145,14 @@ public final class LowkeyVaultManagementClientImpl implements LowkeyVaultManagem
         final String path = optionalURI.map(u -> MANAGEMENT_VAULT_TIME_PATH).orElse(MANAGEMENT_VAULT_TIME_ALL_PATH);
         final URI uri = UriUtil.uriBuilderForPath(vaultUrl, path, parameters);
         final HttpRequest request = new HttpRequest(HttpMethod.PUT, uri.toString())
-                .setHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON);
+                .setHeader(HttpHeaderName.CONTENT_TYPE, APPLICATION_JSON);
         sendRaw(request);
     }
 
     @Override
     public String exportActive() {
         final URI uri = UriUtil.uriBuilderForPath(vaultUrl, MANAGEMENT_VAULT_EXPORT_ACTIVE_PATH);
-        final HttpRequest request = new HttpRequest(HttpMethod.GET, uri.toString())
-                .setHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON);
+        final HttpRequest request = new HttpRequest(HttpMethod.GET, uri.toString());
         return sendRaw(request).getResponseBodyAsString();
     }
 
@@ -192,7 +183,7 @@ public final class LowkeyVaultManagementClientImpl implements LowkeyVaultManagem
     private VaultModel performAliasUpdate(final Map<String, String> parameters) {
         final URI uri = UriUtil.uriBuilderForPath(vaultUrl, MANAGEMENT_VAULT_ALIAS_PATH, parameters);
         final HttpRequest request = new HttpRequest(HttpMethod.PATCH, uri.toString())
-                .setHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON);
+                .setHeader(HttpHeaderName.CONTENT_TYPE, APPLICATION_JSON);
         return sendAndProcess(request, r -> r.getResponseObject(VaultModel.class));
     }
 

--- a/lowkey-vault-client/src/test/java/com/github/nagyesta/lowkeyvault/http/management/impl/LowkeyVaultManagementClientImplTest.java
+++ b/lowkey-vault-client/src/test/java/com/github/nagyesta/lowkeyvault/http/management/impl/LowkeyVaultManagementClientImplTest.java
@@ -223,7 +223,7 @@ class LowkeyVaultManagementClientImplTest {
             final HttpRequest request = httpRequestArgumentCaptor.getValue();
             Assertions.assertEquals("/management/vault", request.getUrl().getPath());
             Assertions.assertEquals(HttpMethod.GET, request.getHttpMethod());
-            Assertions.assertEquals(APPLICATION_JSON, request.getHeaders().getValue(HttpHeaderName.CONTENT_TYPE));
+            Assertions.assertNull(request.getHeaders().get(HttpHeaderName.CONTENT_TYPE));
             verify(response).getStatusCode();
             verify(response).getBodyAsString(eq(StandardCharsets.UTF_8));
             verify(objectReader).forType(eq(VAULT_MODEL_LIST_TYPE_REF));
@@ -250,7 +250,7 @@ class LowkeyVaultManagementClientImplTest {
             final HttpRequest request = httpRequestArgumentCaptor.getValue();
             Assertions.assertEquals("/management/vault/deleted", request.getUrl().getPath());
             Assertions.assertEquals(HttpMethod.GET, request.getHttpMethod());
-            Assertions.assertEquals(APPLICATION_JSON, request.getHeaders().getValue(HttpHeaderName.CONTENT_TYPE));
+            Assertions.assertNull(request.getHeaders().get(HttpHeaderName.CONTENT_TYPE));
             verify(response).getStatusCode();
             verify(response).getBodyAsString(eq(StandardCharsets.UTF_8));
             verify(objectReader).forType(eq(VAULT_MODEL_LIST_TYPE_REF));
@@ -276,7 +276,7 @@ class LowkeyVaultManagementClientImplTest {
             final HttpRequest request = httpRequestArgumentCaptor.getValue();
             Assertions.assertEquals("/management/vault", request.getUrl().getPath());
             Assertions.assertEquals(HttpMethod.DELETE, request.getHttpMethod());
-            Assertions.assertEquals(APPLICATION_JSON, request.getHeaders().getValue(HttpHeaderName.CONTENT_TYPE));
+            Assertions.assertNull(request.getHeaders().get(HttpHeaderName.CONTENT_TYPE));
             verify(response).getStatusCode();
             verify(response).getBodyAsString(eq(StandardCharsets.UTF_8));
             verify(objectReader).forType(eq(Boolean.class));
@@ -471,7 +471,7 @@ class LowkeyVaultManagementClientImplTest {
             final HttpRequest request = httpRequestArgumentCaptor.getValue();
             Assertions.assertEquals("/management/vault/purge", request.getUrl().getPath());
             Assertions.assertEquals(HttpMethod.DELETE, request.getHttpMethod());
-            Assertions.assertEquals(APPLICATION_JSON, request.getHeaders().getValue(HttpHeaderName.CONTENT_TYPE));
+            Assertions.assertNull(request.getHeaders().get(HttpHeaderName.CONTENT_TYPE));
             verify(response).getStatusCode();
             verify(response).getBodyAsString(eq(StandardCharsets.UTF_8));
             verify(objectReader).forType(eq(Boolean.class));
@@ -609,7 +609,7 @@ class LowkeyVaultManagementClientImplTest {
             final HttpRequest request = httpRequestArgumentCaptor.getValue();
             Assertions.assertEquals("/management/vault/export", request.getUrl().getPath());
             Assertions.assertEquals(HttpMethod.GET, request.getHttpMethod());
-            Assertions.assertEquals(APPLICATION_JSON, request.getHeaders().getValue(HttpHeaderName.CONTENT_TYPE));
+            Assertions.assertNull(request.getHeaders().get(HttpHeaderName.CONTENT_TYPE));
             verify(response).getStatusCode();
             verify(response).getBodyAsString(eq(StandardCharsets.UTF_8));
         }


### PR DESCRIPTION
__Issue:__ #1040

### Description
<!-- A short summary of changes -->

- Removes Content-Type header requirement from GET and DELETE endpoints
- Updates tests

### Entry point
<!-- Where should the reviewer start in order to properly understand the PR? -->

-

### Checklists

- [x] I have rebased my branch
- [x] My commit message is meaningful
- [x] The commit messages use semantic versioning: ```{major}```, ```{minor}``` or ```{patch}```
- [x] The changes are focusing on the issue at hand
- [x] I have maintained or increased test coverage

### Notes

-
<!-- Any additional remarks you may have. -->
