### PR TITLE
Make WWW-Authenticate header resource parameter configurable

### DIFF
--- a/lowkey-vault-app/README.md
+++ b/lowkey-vault-app/README.md
@@ -94,6 +94,19 @@ Set `--server.port=<port>` as an argument as usual with Spring Boot apps:
 java -jar lowkey-vault-app-<version>.jar --server.port=8443
 ```
 
+## Challenge resource URI
+
+The official Azure Key Vault clients verify the challenge resource URL returned by the server (see
+[blog](https://devblogs.microsoft.com/azure-sdk/guidance-for-applications-using-the-key-vault-libraries/)). You can either set
+`DisableChallengeResourceVerification=true` in your client, or you can configure the resource URL returned by the Lowkey Vault:
+
+```
+java -jar lowkey-vault-app-<version>.jar --LOWKEY_AUTH_RESOURCE="vault.azure.net"
+```
+
+You should be running the Lowkey Vault with a resolvable hostname as a subdomain of `vault.azure.net` (e.g. `lowkey.vault.azure.net`) and
+have appropriate SSL certificates registered if you choose to configure the auth resource.
+
 ### Importing vault content at startup
 
 When you need to automatically import the contents of the vaults form a previously created JSON export, you can

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/TestConstants.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/TestConstants.java
@@ -46,6 +46,7 @@ public final class TestConstants {
     public static final String LOWKEY_VAULT = "lowkey-vault";
     public static final String DEFAULT_SUB = "default.";
     public static final String DEFAULT_LOWKEY_VAULT = DEFAULT_SUB + LOWKEY_VAULT;
+    public static final String AZURE_CLOUD = "vault.azure.net";
     //</editor-fold>
 
     //<editor-fold defaultstate="collapsed" desc="Port">

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/TestConstantsUri.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/TestConstantsUri.java
@@ -25,6 +25,7 @@ public final class TestConstantsUri {
     public static final URI HTTPS_DEFAULT_LOWKEY_VAULT = URI.create(HTTPS + DEFAULT_SUB + LOWKEY_VAULT);
     public static final URI HTTPS_DEFAULT_LOWKEY_VAULT_8443 = URI.create(HTTPS_DEFAULT_LOWKEY_VAULT + PORT_8443);
     public static final URI HTTPS_DEFAULT_LOWKEY_VAULT_80 = URI.create(HTTPS_DEFAULT_LOWKEY_VAULT + PORT_80);
+    public static final URI HTTPS_AZURE_CLOUD = URI.create(HTTPS + AZURE_CLOUD);
     //</editor-fold>
 
     public static String getRandomVaultUriAsString() {


### PR DESCRIPTION
__Issue:__ #1149

### Description

Adds an additional `LOWKEY_AUTH_RESOURCE` argument which is used in the WWW-Authenticate header for the resource parameter. Defaults to `"localhost"`.

### Entry point

Probably with the #1149 issue.

### Checklists

- [x] I have rebased my branch
- [x] My commit message is meaningful
- [ ] The commit messages use semantic versioning: ```{major}```, ```{minor}``` or ```{patch}```
    - **No, missed this part when reviewing existing commits - also not sure which would be best for this potential patch**
- [x] The changes are focusing on the issue at hand
- [x] I have maintained or increased test coverage

### Notes

Same notes as the linked issue:

- Haven't kept the existing behaviour of using the request URI as the value of the resource parameter by default, but could presumably be amended with a conditional in the constructor. Just not 100% how Java+Spring handles unset `@Value` arguments (Null? Empty String?)
- Personally not sure if using `@Value` in the auth filter constructor is a "good thing", but took inspiration from the `VaultImporterProperties` class and ... it does seem the shortest route to a possible fix
- (Force pushed to fix the DCO/Signed-off-by footer)

One last thought:

- Maybe this is overcomplicating things. If `disableChallengeResourceVerification` is in use, I guess the `resource` parameter doesn't matter. If it's not, it's running a custom hostname, and presumably that would be a subdomain of `vault.azure.net` so ... maybe it could just be straight up hard-coded in a similar way to the Basis-Theory emulator? 🤷🏻‍♂️ 