### PR TITLE
Allow customization of the WWW-Authenticate headers

### DIFF
--- a/lowkey-vault-app/README.md
+++ b/lowkey-vault-app/README.md
@@ -94,7 +94,7 @@ Set `--server.port=<port>` as an argument as usual with Spring Boot apps:
 java -jar lowkey-vault-app-<version>.jar --server.port=8443
 ```
 
-## Challenge resource URI
+### Overriding the challenge resource URI
 
 The official Azure Key Vault clients verify the challenge resource URL returned by the server (see
 [blog](https://devblogs.microsoft.com/azure-sdk/guidance-for-applications-using-the-key-vault-libraries/)). You can either set
@@ -104,8 +104,24 @@ The official Azure Key Vault clients verify the challenge resource URL returned 
 java -jar lowkey-vault-app-<version>.jar --LOWKEY_AUTH_RESOURCE="vault.azure.net"
 ```
 
-You should be running the Lowkey Vault with a resolvable hostname as a subdomain of `vault.azure.net` (e.g. `lowkey.vault.azure.net`) and
-have appropriate SSL certificates registered if you choose to configure the auth resource.
+> [!NOTE]
+> You should be running Lowkey Vault with a resolvable hostname as a subdomain of `vault.azure.net` (e.g. `lowkey.vault.azure.net`) and have appropriate SSL certificates registered if you choose to configure the auth resource.
+
+> [!WARNING] 
+> This property is only intended to be used in case you absolutely cannot disable your challenge resource verification because it raises the complexity of your setup significantly and there are no guarantees that the clients will keep working with this workaround. Therefore, this is NOT recommended to be used. Please consider following [the official guidance](https://devblogs.microsoft.com/azure-sdk/guidance-for-applications-using-the-key-vault-libraries/) instead.
+
+### Using the Token endpoint with a custom realm
+
+By default, the Token endpoint includes the `WWW-Authenticate` response header with the `Basic realm=assumed-identity` value.
+If you need to change the realm (for example because you are using Managed Identity authentication with the latest Python libraries)
+you can use the `LOWKEY_TOKEN_REALM` configuration property to override it as seen in the example below:
+
+```
+java -jar lowkey-vault-app-<version>.jar --LOWKEY_TOKEN_REALM="local"
+```
+
+Using the configuration above, the value of the response header would change to `Basic realm=local`.
+
 
 ### Importing vault content at startup
 

--- a/lowkey-vault-app/README.md
+++ b/lowkey-vault-app/README.md
@@ -94,6 +94,19 @@ Set `--server.port=<port>` as an argument as usual with Spring Boot apps:
 java -jar lowkey-vault-app-<version>.jar --server.port=8443
 ```
 
+## Challenge resource URI
+
+The official Azure Key Vault clients verify the challenge resource URL returned by the server (see
+[blog](https://devblogs.microsoft.com/azure-sdk/guidance-for-applications-using-the-key-vault-libraries/)). You can either set
+`DisableChallengeResourceVerification=true` in your client, or you can configure the resource URL returned by the Lowkey Vault:
+
+```
+java -jar lowkey-vault-app-<version>.jar --LOWKEY_AUTH_RESOURCE="vault.azure.net"
+```
+
+You should be running the Lowkey Vault with a resolvable hostname as a subdomain of `vault.azure.net` (e.g. `lowkey.vault.azure.net`) and
+have appropriate SSL certificates registered if you choose to configure the auth resource.
+
 ### Importing vault content at startup
 
 When you need to automatically import the contents of the vaults form a previously created JSON export, you can

--- a/lowkey-vault-app/build.gradle
+++ b/lowkey-vault-app/build.gradle
@@ -42,7 +42,7 @@ test {
     useJUnitPlatform()
     systemProperty("junit.jupiter.extensions.autodetection.enabled", true)
     systemProperty("junit.jupiter.execution.parallel.enabled", true)
-    systemProperty("junit.jupiter.execution.parallel.mode.default", "concurrent")
+    systemProperty("junit.jupiter.execution.parallel.mode.default", "same_thread")
     systemProperty("junit.jupiter.execution.parallel.mode.classes.default", "concurrent")
 }
 

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/controller/ManagedIdentityTokenController.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/controller/ManagedIdentityTokenController.java
@@ -1,7 +1,10 @@
 package com.github.nagyesta.lowkeyvault.controller;
 
 import com.github.nagyesta.lowkeyvault.model.TokenResponse;
+import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -13,10 +16,19 @@ import java.net.URI;
 @RestController
 public class ManagedIdentityTokenController {
 
+    private final String tokenRealm;
+
+    public ManagedIdentityTokenController(
+            @NonNull @Value("${LOWKEY_TOKEN_REALM:assumed-identity}") final String tokenRealm) {
+        this.tokenRealm = tokenRealm;
+    }
+
     @GetMapping(value = {"/metadata/identity/oauth2/token", "/metadata/identity/oauth2/token/"})
     public ResponseEntity<TokenResponse> get(@RequestParam("resource") final URI resource) {
         final TokenResponse body = new TokenResponse(resource);
         log.info("Returning token: {}", body);
-        return ResponseEntity.ok(body);
+        return ResponseEntity.ok()
+                .header(HttpHeaders.WWW_AUTHENTICATE, "Basic realm=" + tokenRealm)
+                .body(body);
     }
 }

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/TestConstants.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/TestConstants.java
@@ -46,6 +46,7 @@ public final class TestConstants {
     public static final String LOWKEY_VAULT = "lowkey-vault";
     public static final String DEFAULT_SUB = "default.";
     public static final String DEFAULT_LOWKEY_VAULT = DEFAULT_SUB + LOWKEY_VAULT;
+    public static final String AZURE_CLOUD = "vault.azure.net";
     //</editor-fold>
 
     //<editor-fold defaultstate="collapsed" desc="Port">

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/TestConstantsUri.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/TestConstantsUri.java
@@ -25,6 +25,7 @@ public final class TestConstantsUri {
     public static final URI HTTPS_DEFAULT_LOWKEY_VAULT = URI.create(HTTPS + DEFAULT_SUB + LOWKEY_VAULT);
     public static final URI HTTPS_DEFAULT_LOWKEY_VAULT_8443 = URI.create(HTTPS_DEFAULT_LOWKEY_VAULT + PORT_8443);
     public static final URI HTTPS_DEFAULT_LOWKEY_VAULT_80 = URI.create(HTTPS_DEFAULT_LOWKEY_VAULT + PORT_80);
+    public static final URI HTTPS_AZURE_CLOUD = URI.create(HTTPS + AZURE_CLOUD);
     //</editor-fold>
 
     public static String getRandomVaultUriAsString() {

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/controller/common/TokenControllerTest.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/controller/common/TokenControllerTest.java
@@ -4,17 +4,20 @@ import com.github.nagyesta.lowkeyvault.controller.ManagedIdentityTokenController
 import com.github.nagyesta.lowkeyvault.model.TokenResponse;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 import java.net.URI;
+import java.util.List;
 
 class TokenControllerTest {
 
     @Test
     void testGetShouldReturnTokenWhenCalled() {
         //given
-        final ManagedIdentityTokenController underTest = new ManagedIdentityTokenController();
+        final String tokenRealm = "realm-name";
+        final ManagedIdentityTokenController underTest = new ManagedIdentityTokenController(tokenRealm);
         final URI resource = URI.create("https://localhost:8443/");
 
         //when
@@ -26,5 +29,16 @@ class TokenControllerTest {
         Assertions.assertNotNull(actual.getBody());
         Assertions.assertEquals(resource, actual.getBody().resource());
         Assertions.assertEquals("dummy", actual.getBody().accessToken());
+        Assertions.assertEquals(List.of("Basic realm=" + tokenRealm), actual.getHeaders().get(HttpHeaders.WWW_AUTHENTICATE));
+    }
+
+    @Test
+    void testConstructorShouldThrowExceptionWhenCalledWithNull() {
+        //given
+
+        //when
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new ManagedIdentityTokenController(null));
+
+        //then + exception
     }
 }

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/filter/CommonAuthHeaderFilterTest.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/filter/CommonAuthHeaderFilterTest.java
@@ -80,9 +80,8 @@ class CommonAuthHeaderFilterTest {
     @ValueSource(strings = {EMPTY, HEADER_VALUE})
     void testDoFilterInternalShouldNotCallNextOnChainWhenAuthorizationHeaderMissing(final String headerValue)
             throws ServletException, IOException {
-        final CommonAuthHeaderFilter underTest = new CommonAuthHeaderFilter(LOCALHOST);
-
         //given
+        final CommonAuthHeaderFilter underTest = new CommonAuthHeaderFilter(CommonAuthHeaderFilter.OMIT_DEFAULT);
         when(request.getHeader(eq(HttpHeaders.AUTHORIZATION))).thenReturn(headerValue);
 
         //when
@@ -102,9 +101,8 @@ class CommonAuthHeaderFilterTest {
     @ValueSource(strings = {EMPTY, HEADER_VALUE})
     void testDoFilterInternalShouldAddTokenToResponseHeaderWhenCalled(final String headerValue)
             throws ServletException, IOException {
-        final CommonAuthHeaderFilter underTest = new CommonAuthHeaderFilter(LOCALHOST);
-
         //given
+        final CommonAuthHeaderFilter underTest = new CommonAuthHeaderFilter(CommonAuthHeaderFilter.OMIT_DEFAULT);
         when(request.getHeader(eq(HttpHeaders.AUTHORIZATION))).thenReturn(headerValue);
 
         //when
@@ -118,9 +116,8 @@ class CommonAuthHeaderFilterTest {
     @MethodSource("authResourceProvider")
     void testDoFilterInternalShouldSetResourceOnResponseHeaderWhenCalled(final String authResource, final URI expected)
             throws ServletException, IOException {
-        final CommonAuthHeaderFilter underTest = new CommonAuthHeaderFilter(authResource);
-
         //given
+        final CommonAuthHeaderFilter underTest = new CommonAuthHeaderFilter(authResource);
         when(request.getHeader(eq(HttpHeaders.AUTHORIZATION))).thenReturn(HEADER_VALUE);
 
         //when
@@ -134,9 +131,8 @@ class CommonAuthHeaderFilterTest {
     @MethodSource("hostAndPortProvider")
     void testDoFilterInternalShouldSetRequestBaseUriRequestAttributeWhenCalled(
             final String hostName, final int port, final String path, final URI expected) throws ServletException, IOException {
-        final CommonAuthHeaderFilter underTest = new CommonAuthHeaderFilter(LOCALHOST);
-
         //given
+        final CommonAuthHeaderFilter underTest = new CommonAuthHeaderFilter(CommonAuthHeaderFilter.OMIT_DEFAULT);
         when(request.getServerName()).thenReturn(hostName);
         when(request.getServerPort()).thenReturn(port);
         when(request.getRequestURI()).thenReturn(path);
@@ -153,9 +149,8 @@ class CommonAuthHeaderFilterTest {
 
     @Test
     void testShouldNotFilterShouldReturnTrueWhenRequestBaseUriIsPing() {
-        final CommonAuthHeaderFilter underTest = new CommonAuthHeaderFilter(LOCALHOST);
-
         //given
+        final CommonAuthHeaderFilter underTest = new CommonAuthHeaderFilter(CommonAuthHeaderFilter.OMIT_DEFAULT);
         when(request.getRequestURI()).thenReturn("/ping");
 
         //when
@@ -164,5 +159,15 @@ class CommonAuthHeaderFilterTest {
         //then
         Assertions.assertTrue(actual);
         verify(request, atLeastOnce()).getRequestURI();
+    }
+
+    @Test
+    void testConstructorShouldThrowExceptionWhenCalledWithNull() {
+        //given
+
+        //when
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new CommonAuthHeaderFilter(null));
+
+        //then + exception
     }
 }


### PR DESCRIPTION
__Issue:__ #1149 

### Description
<!-- A short summary of changes -->

- Adds new properties to allow customization of the `WWW-Authenticate` header
- Changes the `CommonAuthHeaderFilter` to support custom resource URIs
- Uses default value of the `LOWKEY_AUTH_RESOURCE` property to keep existing logic in place
- Changes token endpoint to return `WWW-Authenticate` headers as well
- Allows configuration of the realm used by the token endpoint using `LOWKEY_TOKEN_REALM`
- Updates tests
- Updates documentation

### Entry point
<!-- Where should the reviewer start in order to properly understand the PR? -->

-

### Checklists

- [x] I have rebased my branch
- [x] My commit message is meaningful
- [x] The commit messages use semantic versioning: ```{major}```, ```{minor}``` or ```{patch}```
- [x] The changes are focusing on the issue at hand
- [x] I have maintained or increased test coverage

### Notes

- Uses the first commit as-is from the #1150 PR opened by @craig0990 (Thank you!) . This new PR was only necessary to allow successful test runs using the pipeline and incorporate my own adjustments.

<!-- Any additional remarks you may have. -->
