### PR TITLE
Base64 cannot be decoded to KeyStore with Java client

### DIFF
--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/certificate/impl/CertContentType.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/certificate/impl/CertContentType.java
@@ -239,6 +239,6 @@ public enum CertContentType {
     }
 
     static String encodeAsBase64String(final byte[] bytes) {
-        return Base64.getMimeEncoder().encodeToString(bytes);
+        return Base64.getEncoder().encodeToString(bytes);
     }
 }

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/service/certificate/impl/CertContentTypeTest.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/service/certificate/impl/CertContentTypeTest.java
@@ -19,6 +19,7 @@ import java.security.cert.Certificate;
 import java.security.cert.CertificateEncodingException;
 import java.util.List;
 import java.util.Objects;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import static com.github.nagyesta.lowkeyvault.service.certificate.impl.CertContentType.PEM;
@@ -468,7 +469,8 @@ class CertContentTypeTest {
         final String actual = CertContentType.encodeAsBase64String(input);
 
         //then
-        Assertions.assertEquals(expected, actual);
+        final String expectedWithoutLineBreaks = expected.replaceAll(Pattern.quote("\r\n"), "");
+        Assertions.assertEquals(expectedWithoutLineBreaks, actual);
     }
 
     @ParameterizedTest

--- a/lowkey-vault-docker/src/test/java/com/github/nagyesta/lowkeyvault/steps/CertificateStepDefAssertion.java
+++ b/lowkey-vault-docker/src/test/java/com/github/nagyesta/lowkeyvault/steps/CertificateStepDefAssertion.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import static java.util.Base64.getDecoder;
 import static java.util.Base64.getMimeDecoder;
 
 public class CertificateStepDefAssertion extends CommonAssertions {
@@ -305,7 +306,7 @@ public class CertificateStepDefAssertion extends CommonAssertions {
             final CertificateFactory fact = CertificateFactory.getInstance("X.509");
             certificate = (X509Certificate) fact.generateCertificate(new ByteArrayInputStream(encodedCertificate));
         } else {
-            final byte[] bytes = getMimeDecoder().decode(value);
+            final byte[] bytes = getDecoder().decode(value);
             final KeyStore keyStore = getKeyStore(bytes, DEFAULT_PASSWORD);
             final String alias = findAlias(keyStore);
             certificate = (X509Certificate) keyStore.getCertificate(alias);


### PR DESCRIPTION
__Issue:__ #1295

### Description
<!-- A short summary of changes -->

- Fixes encoder to generate same format as before
- Changes end-to-end tests to only accept the right format (and no longer accept Base64Mime)

### Entry point
<!-- Where should the reviewer start in order to properly understand the PR? -->

-

### Checklists

- [x] I have rebased my branch
- [x] My commit message is meaningful
- [x] The commit messages use semantic versioning: ```{major}```, ```{minor}``` or ```{patch}```
- [x] The changes are focusing on the issue at hand
- [x] I have maintained or increased test coverage

### Notes

-
<!-- Any additional remarks you may have. -->
