### PR TITLE
Lowkey Vault Docker does not support dynamic host ports

### DIFF
--- a/lowkey-vault-app/README.md
+++ b/lowkey-vault-app/README.md
@@ -94,6 +94,18 @@ Set `--server.port=<port>` as an argument as usual with Spring Boot apps:
 java -jar lowkey-vault-app-<version>.jar --server.port=8443
 ```
 
+### Relaxed port matching
+
+If you want to use Lowkey Vault in a scenario where you are accessing the vault through a dynamically mapped port, 
+for example using a random host port when exposing your container port with Testcontainers, you can tell Lowkey Vault
+to ignore the port number when searching for a vault based on the request authority (essentially only matching based
+on the request's hostname). To activate this feature, you need to use `v2.7.0` or higher, and provide the
+`--LOWKEY_VAULT_RELAXED_PORTS=true` argument during startup:
+
+```shell
+java -jar lowkey-vault-app-<version>.jar --LOWKEY_VAULT_RELAXED_PORTS=true
+```
+
 ### Overriding the challenge resource URI
 
 The official Azure Key Vault clients verify the challenge resource URL returned by the server (see

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/context/util/VaultUriUtil.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/context/util/VaultUriUtil.java
@@ -39,4 +39,8 @@ public final class VaultUriUtil {
         final int port = Integer.parseInt(StringUtils.substringAfter(authority, COLON));
         return VaultUriUtil.vaultUri(hostname, port);
     }
+
+    public static URI replacePortWith(final URI uri, final int port) {
+        return VaultUriUtil.vaultUri(uri.getHost(), port);
+    }
 }

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/vault/VaultFake.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/vault/VaultFake.java
@@ -8,10 +8,11 @@ import com.github.nagyesta.lowkeyvault.service.secret.SecretVaultFake;
 import java.net.URI;
 import java.time.OffsetDateTime;
 import java.util.Set;
+import java.util.function.Function;
 
 public interface VaultFake {
 
-    boolean matches(URI vaultUri);
+    boolean matches(URI vaultUri, Function<URI, URI> uriMapper);
 
     URI baseUri();
 

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/vault/impl/VaultFakeImpl.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/vault/impl/VaultFakeImpl.java
@@ -18,6 +18,7 @@ import java.time.OffsetDateTime;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 
 @Slf4j
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, doNotUseGetters = true)
@@ -52,8 +53,11 @@ public class VaultFakeImpl implements VaultFake {
     }
 
     @Override
-    public boolean matches(@NonNull final URI vaultUri) {
-        return this.vaultUri.equals(vaultUri) || this.aliases.contains(vaultUri);
+    public boolean matches(@NonNull final URI vaultUri, final Function<URI, URI> uriMapper) {
+        final URI lookupUri = uriMapper.apply(vaultUri);
+        return uriMapper.apply(this.vaultUri).equals(lookupUri) || this.aliases.stream()
+                .map(uriMapper)
+                .anyMatch(lookupUri::equals);
     }
 
     @Override

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/ResourceUtils.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/ResourceUtils.java
@@ -1,12 +1,12 @@
 package com.github.nagyesta.lowkeyvault;
 
-import org.apache.tomcat.util.codec.binary.Base64;
 import org.junit.jupiter.api.Assertions;
 import org.springframework.util.StreamUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Optional;
 
 public final class ResourceUtils {
@@ -28,7 +28,7 @@ public final class ResourceUtils {
     public static String loadResourceAsBase64String(final String resource) {
         final byte[] binaryData = loadResourceAsByteArray(resource);
         return Optional.ofNullable(binaryData)
-                .map(binary -> new Base64().encodeAsString(binary))
+                .map(binary -> Base64.getEncoder().encodeToString(binary))
                 .orElse(null);
     }
 

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/TestConstants.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/TestConstants.java
@@ -54,6 +54,7 @@ public final class TestConstants {
     public static final int TOMCAT_SECURE_PORT = 8443;
     public static final int HTTP_PORT = 80;
     public static final String PORT_80 = ":80";
+    public static final String PORT_443 = ":443";
     public static final String PORT_8443 = ":8443";
     //</editor-fold>
 

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/TestConstantsUri.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/TestConstantsUri.java
@@ -20,6 +20,7 @@ public final class TestConstantsUri {
     public static final URI HTTPS_LOOP_BACK_IP_8443 = URI.create(HTTPS_LOOP_BACK_IP + PORT_8443);
     public static final URI HTTPS_LOOP_BACK_IP_80 = URI.create(HTTPS_LOOP_BACK_IP + PORT_80);
     public static final URI HTTPS_LOWKEY_VAULT = URI.create(HTTPS + LOWKEY_VAULT);
+    public static final URI HTTPS_LOWKEY_VAULT_443 = URI.create(HTTPS + LOWKEY_VAULT + PORT_443);
     public static final URI HTTPS_LOWKEY_VAULT_8443 = URI.create(HTTPS_LOWKEY_VAULT + PORT_8443);
     public static final URI HTTPS_LOWKEY_VAULT_80 = URI.create(HTTPS_LOWKEY_VAULT + PORT_80);
     public static final URI HTTPS_DEFAULT_LOWKEY_VAULT = URI.create(HTTPS + DEFAULT_SUB + LOWKEY_VAULT);

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/controller/BaseVaultConfiguration.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/controller/BaseVaultConfiguration.java
@@ -6,12 +6,14 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 
+import java.util.function.Function;
+
 @Profile("vault")
 @Configuration
 public class BaseVaultConfiguration {
 
     @Bean
     public VaultService vaultService() {
-        return new VaultServiceImpl();
+        return new VaultServiceImpl(Function.identity());
     }
 }

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/mapper/v7_2/key/KeyEntityToV72KeyItemModelConverterTest.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/mapper/v7_2/key/KeyEntityToV72KeyItemModelConverterTest.java
@@ -22,6 +22,7 @@ import org.mockito.MockitoAnnotations;
 import java.net.URI;
 import java.time.OffsetDateTime;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 import static com.github.nagyesta.lowkeyvault.TestConstants.*;
@@ -129,7 +130,8 @@ class KeyEntityToV72KeyItemModelConverterTest {
 
         //given
         when(vault.baseUri()).thenReturn(keyEntityId.vault());
-        when(vault.matches(eq(keyEntityId.vault()))).thenReturn(true);
+        final URI vaultUri = eq(keyEntityId.vault());
+        when(vault.matches(vaultUri, eq(Function.identity()))).thenReturn(true);
         final RsaKeyVaultKeyEntity input = new RsaKeyVaultKeyEntity(keyEntityId, vault, keyParam, null, false);
         input.setTags(tags);
 
@@ -162,7 +164,8 @@ class KeyEntityToV72KeyItemModelConverterTest {
 
         //given
         when(vault.baseUri()).thenReturn(keyEntityId.vault());
-        when(vault.matches(eq(keyEntityId.vault()))).thenReturn(true);
+        final URI vaultUri = eq(keyEntityId.vault());
+        when(vault.matches(vaultUri, eq(Function.identity()))).thenReturn(true);
         final RsaKeyVaultKeyEntity input = new RsaKeyVaultKeyEntity(keyEntityId, vault, keyParam, null, false);
         input.setDeletedDate(deleted);
         input.setScheduledPurgeDate(scheduledPurge);

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/mapper/v7_2/key/KeyEntityToV72KeyVersionItemModelConverterTest.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/mapper/v7_2/key/KeyEntityToV72KeyVersionItemModelConverterTest.java
@@ -19,6 +19,7 @@ import org.mockito.MockitoAnnotations;
 
 import java.net.URI;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 import static com.github.nagyesta.lowkeyvault.TestConstants.*;
@@ -80,7 +81,8 @@ class KeyEntityToV72KeyVersionItemModelConverterTest {
 
         //given
         when(vault.baseUri()).thenReturn(keyEntityId.vault());
-        when(vault.matches(eq(keyEntityId.vault()))).thenReturn(true);
+        final URI vaultUri = eq(keyEntityId.vault());
+        when(vault.matches(vaultUri, eq(Function.identity()))).thenReturn(true);
         final RsaKeyVaultKeyEntity input = new RsaKeyVaultKeyEntity(keyEntityId, vault, keyParam, null, false);
         input.setTags(tags);
 

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/mapper/v7_2/key/KeyEntityToV72ModelConverterTest.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/mapper/v7_2/key/KeyEntityToV72ModelConverterTest.java
@@ -25,6 +25,7 @@ import org.mockito.MockitoAnnotations;
 import java.net.URI;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 import static com.github.nagyesta.lowkeyvault.TestConstants.*;
@@ -214,7 +215,8 @@ class KeyEntityToV72ModelConverterTest {
 
     private void prepareVaultMock(final URI baseUri) {
         when(vault.baseUri()).thenReturn(baseUri);
-        when(vault.matches(eq(baseUri))).thenReturn(true);
+        final URI vaultUri = eq(baseUri);
+        when(vault.matches(vaultUri, eq(Function.identity()))).thenReturn(true);
     }
 
     private void assertCommonFieldsMatch(final Map<String, String> tags,

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/mapper/v7_2/key/KeyEntityToV72PropertiesModelConverterTest.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/mapper/v7_2/key/KeyEntityToV72PropertiesModelConverterTest.java
@@ -20,7 +20,9 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import java.net.URI;
 import java.time.OffsetDateTime;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 import static com.github.nagyesta.lowkeyvault.TestConstants.*;
@@ -60,7 +62,8 @@ class KeyEntityToV72PropertiesModelConverterTest {
         underTest = new KeyEntityToV72PropertiesModelConverter(registry);
         when(vault.keyVaultFake()).thenReturn(keyVault);
         when(vault.baseUri()).thenReturn(HTTPS_LOCALHOST);
-        when(vault.matches(eq(HTTPS_LOCALHOST))).thenReturn(true);
+        final URI vaultUri = eq(HTTPS_LOCALHOST);
+        when(vault.matches(vaultUri, eq(Function.identity()))).thenReturn(true);
     }
 
     @AfterEach

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/mapper/v7_2/secret/SecretEntityToV72ModelConverterTest.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/mapper/v7_2/secret/SecretEntityToV72ModelConverterTest.java
@@ -20,6 +20,7 @@ import org.mockito.MockitoAnnotations;
 import java.net.URI;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 import static com.github.nagyesta.lowkeyvault.TestConstants.*;
@@ -124,7 +125,8 @@ class SecretEntityToV72ModelConverterTest {
 
     private void prepareVaultMock(final URI baseUri) {
         when(vault.baseUri()).thenReturn(baseUri);
-        when(vault.matches(eq(baseUri))).thenReturn(true);
+        final URI vaultUri = eq(baseUri);
+        when(vault.matches(vaultUri, eq(Function.identity()))).thenReturn(true);
     }
 
     private void assertFieldsMatch(final Map<String, String> tags,

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/mapper/v7_2/secret/SecretEntityToV72PropertiesModelConverterTest.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/mapper/v7_2/secret/SecretEntityToV72PropertiesModelConverterTest.java
@@ -16,7 +16,9 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import java.net.URI;
 import java.time.OffsetDateTime;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 import static com.github.nagyesta.lowkeyvault.TestConstants.*;
@@ -57,7 +59,8 @@ class SecretEntityToV72PropertiesModelConverterTest {
         underTest = new SecretEntityToV72PropertiesModelConverter(registry);
         when(vault.secretVaultFake()).thenReturn(secretVault);
         when(vault.baseUri()).thenReturn(HTTPS_LOCALHOST);
-        when(vault.matches(eq(HTTPS_LOCALHOST))).thenReturn(true);
+        final URI vaultUri = eq(HTTPS_LOCALHOST);
+        when(vault.matches(vaultUri, eq(Function.identity()))).thenReturn(true);
     }
 
     @AfterEach

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/mapper/v7_2/secret/SecretEntityToV72SecretItemModelConverterTest.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/mapper/v7_2/secret/SecretEntityToV72SecretItemModelConverterTest.java
@@ -22,6 +22,7 @@ import org.mockito.MockitoAnnotations;
 import java.net.URI;
 import java.time.OffsetDateTime;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 import static com.github.nagyesta.lowkeyvault.TestConstants.*;
@@ -130,7 +131,8 @@ class SecretEntityToV72SecretItemModelConverterTest {
 
         //given
         when(vault.baseUri()).thenReturn(secretEntityId.vault());
-        when(vault.matches(eq(secretEntityId.vault()))).thenReturn(true);
+        final URI vaultUri = eq(secretEntityId.vault());
+        when(vault.matches(vaultUri, eq(Function.identity()))).thenReturn(true);
         final KeyVaultSecretEntity input = new KeyVaultSecretEntity(secretEntityId, vault, value, type);
         input.setTags(tags);
 
@@ -163,7 +165,8 @@ class SecretEntityToV72SecretItemModelConverterTest {
 
         //given
         when(vault.baseUri()).thenReturn(secretEntityId.vault());
-        when(vault.matches(eq(secretEntityId.vault()))).thenReturn(true);
+        final URI vaultUri = eq(secretEntityId.vault());
+        when(vault.matches(vaultUri, eq(Function.identity()))).thenReturn(true);
         final KeyVaultSecretEntity input = new KeyVaultSecretEntity(secretEntityId, vault, value, type);
         input.setDeletedDate(deleted);
         input.setScheduledPurgeDate(scheduledPurge);

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/mapper/v7_2/secret/SecretEntityToV72SecretVersionItemModelConverterTest.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/mapper/v7_2/secret/SecretEntityToV72SecretVersionItemModelConverterTest.java
@@ -19,6 +19,7 @@ import org.mockito.MockitoAnnotations;
 
 import java.net.URI;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 import static com.github.nagyesta.lowkeyvault.TestConstants.*;
@@ -89,7 +90,8 @@ class SecretEntityToV72SecretVersionItemModelConverterTest {
 
         //given
         when(vault.baseUri()).thenReturn(secretEntityId.vault());
-        when(vault.matches(eq(secretEntityId.vault()))).thenReturn(true);
+        final URI vaultUri = eq(secretEntityId.vault());
+        when(vault.matches(vaultUri, eq(Function.identity()))).thenReturn(true);
         final KeyVaultSecretEntity input = new KeyVaultSecretEntity(secretEntityId, vault, value, null);
         input.setTags(tags);
 

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/service/vault/impl/VaultServiceImplTest.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/service/vault/impl/VaultServiceImplTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.net.URI;
 import java.time.OffsetDateTime;
 import java.util.*;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 import static com.github.nagyesta.lowkeyvault.TestConstantsUri.*;
@@ -83,11 +84,22 @@ class VaultServiceImplTest {
                 .build();
     }
 
+    @SuppressWarnings("DataFlowIssue")
+    @Test
+    void testConstructorShouldThrowExceptionWhenCalledWithNull() {
+        //given
+
+        //when
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new VaultServiceImpl(null));
+
+        //then + exception
+    }
+
     @ParameterizedTest
     @MethodSource("valueProvider")
     void testCreateShouldThrowExceptionWhenAlreadyExists(final List<URI> vaults, final URI duplicate) {
         //given
-        final VaultServiceImpl underTest = new VaultServiceImpl();
+        final VaultServiceImpl underTest = new VaultServiceImpl(Function.identity());
         vaults.forEach(underTest::create);
 
         //when
@@ -100,7 +112,7 @@ class VaultServiceImplTest {
     @MethodSource("aliasValueProvider")
     void testCreateShouldThrowExceptionWhenAlreadyExists(final List<URI> vaults, final URI baseUri, final Set<URI> duplicate) {
         //given
-        final VaultServiceImpl underTest = new VaultServiceImpl();
+        final VaultServiceImpl underTest = new VaultServiceImpl(Function.identity());
         vaults.forEach(underTest::create);
 
         //when
@@ -113,7 +125,7 @@ class VaultServiceImplTest {
     @Test
     void testCreateShouldThrowExceptionWhenBaseUriMatchesAlias() {
         //given
-        final VaultServiceImpl underTest = new VaultServiceImpl();
+        final VaultServiceImpl underTest = new VaultServiceImpl(Function.identity());
 
         //when
         Assertions.assertThrows(IllegalArgumentException.class,
@@ -126,7 +138,7 @@ class VaultServiceImplTest {
     @MethodSource("valueProvider")
     void testDeleteShouldReturnFalseWhenAlreadyDeleted(final List<URI> vaults, final URI delete) {
         //given
-        final VaultServiceImpl underTest = new VaultServiceImpl();
+        final VaultServiceImpl underTest = new VaultServiceImpl(Function.identity());
         vaults.forEach(underTest::create);
 
         //when
@@ -142,7 +154,7 @@ class VaultServiceImplTest {
     @MethodSource("valueProvider")
     void testRecoverShouldThrowExceptionWhenNotDeleted(final List<URI> vaults, final URI duplicate) {
         //given
-        final VaultServiceImpl underTest = new VaultServiceImpl();
+        final VaultServiceImpl underTest = new VaultServiceImpl(Function.identity());
         vaults.forEach(underTest::create);
 
         //when
@@ -155,7 +167,7 @@ class VaultServiceImplTest {
     @MethodSource("valueProvider")
     void testPurgeShouldThrowExceptionWhenNotDeleted(final List<URI> vaults, final URI duplicate) {
         //given
-        final VaultServiceImpl underTest = new VaultServiceImpl();
+        final VaultServiceImpl underTest = new VaultServiceImpl(Function.identity());
         vaults.forEach(underTest::create);
 
         //when
@@ -168,7 +180,7 @@ class VaultServiceImplTest {
     @MethodSource("valueProvider")
     void testFindByUriIncludeDeletedShouldReturnValueWhenItMatchesFully(final List<URI> vaults, final URI lookup) {
         //given
-        final VaultServiceImpl underTest = new VaultServiceImpl();
+        final VaultServiceImpl underTest = new VaultServiceImpl(Function.identity());
         vaults.forEach(underTest::create);
         vaults.stream().limit(2).forEach(underTest::delete);
 
@@ -184,7 +196,7 @@ class VaultServiceImplTest {
     @MethodSource("missingValueProvider")
     void testFindByUriIncludeDeletedShouldThrowExceptionWhenItemDoesNotMatchFully(final List<URI> vaults, final URI lookup) {
         //given
-        final VaultServiceImpl underTest = new VaultServiceImpl();
+        final VaultServiceImpl underTest = new VaultServiceImpl(Function.identity());
         vaults.forEach(underTest::create);
         vaults.stream().limit(2).forEach(underTest::delete);
 
@@ -198,7 +210,7 @@ class VaultServiceImplTest {
     @MethodSource("valueProvider")
     void testFindByUriShouldReturnValueWhenItMatchesFully(final List<URI> vaults, final URI lookup) {
         //given
-        final VaultServiceImpl underTest = new VaultServiceImpl();
+        final VaultServiceImpl underTest = new VaultServiceImpl(Function.identity());
         vaults.forEach(underTest::create);
 
         //when
@@ -213,7 +225,7 @@ class VaultServiceImplTest {
     @MethodSource("valueProvider")
     void testFindByUriShouldReturnValueWhenItMatchesFullyAfterRecovery(final List<URI> vaults, final URI lookup) {
         //given
-        final VaultServiceImpl underTest = new VaultServiceImpl();
+        final VaultServiceImpl underTest = new VaultServiceImpl(Function.identity());
         vaults.forEach(uri -> underTest.create(uri, RecoveryLevel.RECOVERABLE, RecoveryLevel.MAX_RECOVERABLE_DAYS_INCLUSIVE, null));
         vaults.forEach(underTest::delete);
         vaults.forEach(underTest::recover);
@@ -230,7 +242,7 @@ class VaultServiceImplTest {
     @MethodSource("valueProvider")
     void testFindByUriShouldNotReturnValueWhenItWasPurged(final List<URI> vaults, final URI lookup) {
         //given
-        final VaultServiceImpl underTest = new VaultServiceImpl();
+        final VaultServiceImpl underTest = new VaultServiceImpl(Function.identity());
         vaults.forEach(uri -> underTest.create(uri, RecoveryLevel.RECOVERABLE, RecoveryLevel.MAX_RECOVERABLE_DAYS_INCLUSIVE, null));
         vaults.forEach(underTest::delete);
         vaults.forEach(underTest::purge);
@@ -245,7 +257,7 @@ class VaultServiceImplTest {
     @MethodSource("missingValueProvider")
     void testFindByUriShouldThrowExceptionWhenItemDoesNotMatchFully(final List<URI> vaults, final URI lookup) {
         //given
-        final VaultServiceImpl underTest = new VaultServiceImpl();
+        final VaultServiceImpl underTest = new VaultServiceImpl(Function.identity());
         vaults.forEach(underTest::create);
 
         //when
@@ -258,7 +270,7 @@ class VaultServiceImplTest {
     @MethodSource("valueProvider")
     void testFindByUriShouldThrowExceptionWhenItemIsDeleted(final List<URI> vaults, final URI lookup) {
         //given
-        final VaultServiceImpl underTest = new VaultServiceImpl();
+        final VaultServiceImpl underTest = new VaultServiceImpl(Function.identity());
         vaults.forEach(uri -> underTest
                 .create(uri, RecoveryLevel.CUSTOMIZED_RECOVERABLE, RecoveryLevel.MIN_RECOVERABLE_DAYS_INCLUSIVE, null));
         vaults.forEach(underTest::delete);
@@ -274,7 +286,7 @@ class VaultServiceImplTest {
     @MethodSource("valueMapProvider")
     void testListAndListDeletedShouldFilterBasedOnDeletedStatusWhenCalled(final Map<URI, Boolean> vaults) {
         //given
-        final VaultServiceImpl underTest = new VaultServiceImpl();
+        final VaultServiceImpl underTest = new VaultServiceImpl(Function.identity());
         vaults.forEach((k, v) -> {
             underTest.create(k, RecoveryLevel.CUSTOMIZED_RECOVERABLE, RecoveryLevel.MIN_RECOVERABLE_DAYS_INCLUSIVE, null);
             if (v) {
@@ -289,11 +301,11 @@ class VaultServiceImplTest {
         //then
         vaults.forEach((k, v) -> {
             if (v) {
-                Assertions.assertTrue(actualActive.stream().noneMatch(vault -> vault.matches(k)));
-                Assertions.assertTrue(actualDeleted.stream().anyMatch(vault -> vault.matches(k)));
+                Assertions.assertTrue(actualActive.stream().noneMatch(vault -> vault.matches(k, Function.identity())));
+                Assertions.assertTrue(actualDeleted.stream().anyMatch(vault -> vault.matches(k, Function.identity())));
             } else {
-                Assertions.assertTrue(actualDeleted.stream().noneMatch(vault -> vault.matches(k)));
-                Assertions.assertTrue(actualActive.stream().anyMatch(vault -> vault.matches(k)));
+                Assertions.assertTrue(actualDeleted.stream().noneMatch(vault -> vault.matches(k, Function.identity())));
+                Assertions.assertTrue(actualActive.stream().anyMatch(vault -> vault.matches(k, Function.identity())));
             }
         });
     }
@@ -302,7 +314,7 @@ class VaultServiceImplTest {
     @MethodSource("valueMapProvider")
     void testListDeletedShouldNotReturnPurgedItemsWhenCalled(final Map<URI, Boolean> vaults) {
         //given
-        final VaultServiceImpl underTest = new VaultServiceImpl();
+        final VaultServiceImpl underTest = new VaultServiceImpl(Function.identity());
         vaults.forEach((k, v) -> {
             if (v) {
                 underTest.create(k, RecoveryLevel.PURGEABLE, null, null);
@@ -319,9 +331,9 @@ class VaultServiceImplTest {
         //then
         vaults.forEach((k, v) -> {
             if (v) {
-                Assertions.assertTrue(actualDeleted.stream().noneMatch(vault -> vault.matches(k)));
+                Assertions.assertTrue(actualDeleted.stream().noneMatch(vault -> vault.matches(k, Function.identity())));
             } else {
-                Assertions.assertTrue(actualDeleted.stream().anyMatch(vault -> vault.matches(k)));
+                Assertions.assertTrue(actualDeleted.stream().anyMatch(vault -> vault.matches(k, Function.identity())));
             }
         });
     }
@@ -330,7 +342,7 @@ class VaultServiceImplTest {
     @ValueSource(ints = {-42, -10, -5, -3, -2, -1, 0})
     void testTimeShiftShouldThrowExceptionWhenCalledWithNegativeOrZero(final int value) {
         //given
-        final VaultServiceImpl underTest = new VaultServiceImpl();
+        final VaultServiceImpl underTest = new VaultServiceImpl(Function.identity());
 
         //when
         Assertions.assertThrows(IllegalArgumentException.class, () -> underTest.timeShift(value, false));
@@ -341,7 +353,7 @@ class VaultServiceImplTest {
     @Test
     void testTimeShiftShouldBeForwardedToEachVaultWhenCalledWithPositive() {
         //given
-        final VaultServiceImpl underTest = new VaultServiceImpl();
+        final VaultServiceImpl underTest = new VaultServiceImpl(Function.identity());
         final VaultFake vaultFake = underTest.create(HTTPS_LOWKEY_VAULT_8443);
         final OffsetDateTime createdOriginal = vaultFake.getCreatedOn();
 
@@ -357,7 +369,7 @@ class VaultServiceImplTest {
     void testUpdateAliasShouldThrowExceptionWhenCalledWithInvalidInput(
             final URI baseUri, final Set<URI> aliases, final URI add, final URI remove, final Class<Exception> expectedException) {
         //given
-        final VaultServiceImpl underTest = new VaultServiceImpl();
+        final VaultServiceImpl underTest = new VaultServiceImpl(Function.identity());
         final VaultFake vaultFake = underTest.create(
                 baseUri, RecoveryLevel.CUSTOMIZED_RECOVERABLE, RecoveryLevel.MAX_RECOVERABLE_DAYS_INCLUSIVE, aliases);
 
@@ -372,7 +384,7 @@ class VaultServiceImplTest {
     void testUpdateAliasShouldAddAndRemoveAliasesWhenCalledWithValidInput(
             final URI baseUri, final Set<URI> aliases, final URI add, final URI remove, final Set<URI> expected) {
         //given
-        final VaultServiceImpl underTest = new VaultServiceImpl();
+        final VaultServiceImpl underTest = new VaultServiceImpl(Function.identity());
         underTest.create(baseUri, RecoveryLevel.CUSTOMIZED_RECOVERABLE, RecoveryLevel.MAX_RECOVERABLE_DAYS_INCLUSIVE, aliases);
 
         //when
@@ -385,7 +397,7 @@ class VaultServiceImplTest {
     @Test
     void testUpdateAliasShouldThrowExceptionWhenVaultNotFound() {
         //given
-        final VaultServiceImpl underTest = new VaultServiceImpl();
+        final VaultServiceImpl underTest = new VaultServiceImpl(Function.identity());
         final VaultFake vaultFake = underTest.create(HTTPS_DEFAULT_LOWKEY_VAULT_8443);
 
         //when

--- a/lowkey-vault-client/src/main/java/com/github/nagyesta/lowkeyvault/http/ApacheHttpResponse.java
+++ b/lowkey-vault-client/src/main/java/com/github/nagyesta/lowkeyvault/http/ApacheHttpResponse.java
@@ -18,7 +18,7 @@ import java.util.Arrays;
 import java.util.Optional;
 
 /**
- * Modified class based on https://github.com/Azure/azure-sdk-for-java/wiki/Custom-HTTP-Clients.
+ * Modified class based on <a href="https://github.com/Azure/azure-sdk-for-java/wiki/Custom-HTTP-Clients">Azure SDK Custom HTTP Clients</a>.
  */
 final class ApacheHttpResponse extends HttpResponse {
     private final int statusCode;

--- a/lowkey-vault-docker/README.md
+++ b/lowkey-vault-docker/README.md
@@ -36,6 +36,19 @@ export LOWKEY_ARGS="--server.port=8444"
 docker run --rm --name lowkey -e LOWKEY_ARGS -d -p 8444:8444 nagyesta/lowkey-vault:<version>
 ```
 
+### Relaxed port matching
+
+If you want to use Lowkey Vault in a scenario where you are accessing the vault through a dynamically mapped port,
+for example using a random host port when exposing your container port with Testcontainers, you can tell Lowkey Vault
+to ignore the port number when searching for a vault based on the request authority (essentially only matching based
+on the request's hostname). To activate this feature, you need to use `v2.7.0` or higher, and provide the
+`--LOWKEY_VAULT_RELAXED_PORTS=true` argument during startup:
+
+```shell
+export LOWKEY_ARGS="--LOWKEY_VAULT_RELAXED_PORTS=true"
+docker run --rm --name lowkey -e LOWKEY_ARGS -d -p 8443 nagyesta/lowkey-vault:<version>
+```
+
 ### Using simulated Managed Identity
 
 In case you want to rely on the built-in simulated Managed Identity token endpoint, you must make sure 

--- a/lowkey-vault-testcontainers/README.md
+++ b/lowkey-vault-testcontainers/README.md
@@ -66,7 +66,7 @@ import static com.github.nagyesta.lowkeyvault.testcontainers.LowkeyVaultContaine
 class Test {
     public LowkeyVaultContainer startVault() {
         //Please consider using latest image regardless of the value in the example
-        final DockerImageName imageName = DockerImageName.parse("nagyesta/lowkey-vault:1.13.0");
+        final DockerImageName imageName = DockerImageName.parse("nagyesta/lowkey-vault:2.6.15");
         final LowkeyVaultContainer lowkeyVaultContainer = lowkeyVault(imageName)
                 .vaultNames(Set.of("default"))
                 .build()
@@ -97,7 +97,6 @@ class Test {
                 .importFile(importFile, BindMode.READ_ONLY)
                 .logicalPort(8443)
                 .logicalHost("127.0.0.1")
-                .hostPort(8443)
                 .build()
                 .withImagePullPolicy(PullPolicy.defaultPolicy());
         lowkeyVaultContainer.start();
@@ -106,6 +105,10 @@ class Test {
 }
 
 ```
+
+> [!NOTE]
+> Since `v2.7.0`, the container can use a dynamically allocated port thanks to the relaxed port matching feature. This will ignore the port number when searching for a vault based on the request authority (essentially only matching based
+on the request's hostname).
 
 #### Example using your own certificate file
 

--- a/lowkey-vault-testcontainers/src/main/java/com/github/nagyesta/lowkeyvault/testcontainers/LowkeyVaultArgLineBuilder.java
+++ b/lowkey-vault-testcontainers/src/main/java/com/github/nagyesta/lowkeyvault/testcontainers/LowkeyVaultArgLineBuilder.java
@@ -11,7 +11,12 @@ public class LowkeyVaultArgLineBuilder {
     private static final String EMPTY = "";
     private static final Pattern NAME_PATTERN = Pattern.compile("^[0-9a-zA-Z-]+$");
 
-    private final List<String> args = new ArrayList<>();
+    private final List<String> args;
+
+    public LowkeyVaultArgLineBuilder() {
+        args = new ArrayList<>();
+        args.add("--LOWKEY_VAULT_RELAXED_PORTS=true");
+    }
 
     public LowkeyVaultArgLineBuilder vaultNames(final Set<String> vaultNames) {
         if (!NO_AUTO_REGISTRATION.equals(vaultNames)) {

--- a/lowkey-vault-testcontainers/src/main/java/com/github/nagyesta/lowkeyvault/testcontainers/LowkeyVaultContainer.java
+++ b/lowkey-vault-testcontainers/src/main/java/com/github/nagyesta/lowkeyvault/testcontainers/LowkeyVaultContainer.java
@@ -109,9 +109,7 @@ public class LowkeyVaultContainer extends GenericContainer<LowkeyVaultContainer>
                 .additionalArgs(containerBuilder.getAdditionalArgs())
                 .build();
 
-        if (!args.isEmpty()) {
-            withEnv("LOWKEY_ARGS", String.join(" ", args));
-        }
+        withEnv("LOWKEY_ARGS", String.join(" ", args));
         waitingFor(Wait.forLogMessage("(?s).*Started LowkeyVaultApp.*$", 1));
     }
 
@@ -158,7 +156,7 @@ public class LowkeyVaultContainer extends GenericContainer<LowkeyVaultContainer>
      * @return authority of the default vault base URL.
      */
     public String getDefaultVaultAuthority() {
-        return LOCALHOST + PORT_SEPARATOR + CONTAINER_PORT;
+        return LOCALHOST + PORT_SEPARATOR + getMappedPort(CONTAINER_PORT);
     }
 
     /**
@@ -168,7 +166,7 @@ public class LowkeyVaultContainer extends GenericContainer<LowkeyVaultContainer>
      * @return authority of the given vault base URL.
      */
     public String getVaultAuthority(final String vaultName) {
-        return Objects.requireNonNull(vaultName) + DOT + LOCALHOST + PORT_SEPARATOR + CONTAINER_PORT;
+        return Objects.requireNonNull(vaultName) + DOT + LOCALHOST + PORT_SEPARATOR + getMappedPort(CONTAINER_PORT);
     }
 
     /**

--- a/lowkey-vault-testcontainers/src/main/java/com/github/nagyesta/lowkeyvault/testcontainers/LowkeyVaultContainerBuilder.java
+++ b/lowkey-vault-testcontainers/src/main/java/com/github/nagyesta/lowkeyvault/testcontainers/LowkeyVaultContainerBuilder.java
@@ -102,6 +102,15 @@ public final class LowkeyVaultContainerBuilder {
         return this;
     }
 
+    /**
+     * Sets a fixed host port for the port mapping.
+     *
+     * @param hostPort The host port we want to map the Lowkey Vault HTTPS port.
+     * @return this
+     * @deprecated No longer recommended, containers start with relaxed port configuration by default,
+     * therefore the random port assigned by Testcontainers can be used in Vault URLs without issues.
+     */
+    @Deprecated
     public LowkeyVaultContainerBuilder hostPort(final int hostPort) {
         if (hostPort < 1) {
             throw new IllegalArgumentException("Host port cannot be zero or negative.");

--- a/lowkey-vault-testcontainers/src/test/java/com/github/nagyesta/lowkeyvault/testcontainers/AbstractLowkeyVaultContainerTest.java
+++ b/lowkey-vault-testcontainers/src/test/java/com/github/nagyesta/lowkeyvault/testcontainers/AbstractLowkeyVaultContainerTest.java
@@ -6,12 +6,27 @@ import com.azure.core.http.HttpMethod;
 import com.azure.core.http.HttpRequest;
 import com.azure.core.http.policy.FixedDelay;
 import com.azure.core.http.policy.RetryPolicy;
+import com.azure.core.util.Context;
+import com.azure.security.keyvault.keys.KeyClient;
+import com.azure.security.keyvault.keys.KeyClientBuilder;
+import com.azure.security.keyvault.keys.KeyServiceVersion;
+import com.azure.security.keyvault.keys.cryptography.CryptographyClient;
+import com.azure.security.keyvault.keys.cryptography.CryptographyClientBuilder;
+import com.azure.security.keyvault.keys.cryptography.CryptographyServiceVersion;
+import com.azure.security.keyvault.keys.cryptography.models.DecryptParameters;
+import com.azure.security.keyvault.keys.cryptography.models.DecryptResult;
+import com.azure.security.keyvault.keys.cryptography.models.EncryptParameters;
+import com.azure.security.keyvault.keys.cryptography.models.EncryptResult;
+import com.azure.security.keyvault.keys.models.CreateOctKeyOptions;
+import com.azure.security.keyvault.keys.models.KeyOperation;
+import com.azure.security.keyvault.keys.models.KeyVaultKey;
 import com.azure.security.keyvault.secrets.SecretClient;
 import com.azure.security.keyvault.secrets.SecretClientBuilder;
 import com.azure.security.keyvault.secrets.SecretServiceVersion;
 import com.azure.security.keyvault.secrets.models.KeyVaultSecret;
 import org.junit.jupiter.api.Assertions;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 
 public class AbstractLowkeyVaultContainerTest {
@@ -25,6 +40,8 @@ public class AbstractLowkeyVaultContainerTest {
     }
 
     protected void verifyConnectionIsWorking(final String vaultUrl, final HttpClient httpClient, final TokenCredential credential) {
+        Assertions.assertFalse(vaultUrl.endsWith(":8443"), "Vault URL should use random port instead of '8443'");
+
         final SecretClient secretClient = new SecretClientBuilder()
                 .vaultUrl(vaultUrl)
                 .credential(credential)
@@ -33,10 +50,46 @@ public class AbstractLowkeyVaultContainerTest {
                 .disableChallengeResourceVerification()
                 .retryPolicy(new RetryPolicy(new FixedDelay(0, Duration.ZERO)))
                 .buildClient();
+        final KeyClient keyClient = new KeyClientBuilder()
+                .vaultUrl(vaultUrl)
+                .credential(credential)
+                .httpClient(httpClient)
+                .serviceVersion(KeyServiceVersion.V7_3)
+                .disableChallengeResourceVerification()
+                .retryPolicy(new RetryPolicy(new FixedDelay(0, Duration.ZERO)))
+                .buildClient();
 
         final KeyVaultSecret secret = secretClient.setSecret(NAME, VALUE);
-
         Assertions.assertNotNull(secret);
+        Assertions.assertTrue(secret.getId().startsWith(vaultUrl), "Secret Id should start with vault URL '" + vaultUrl + "'");
+
+        final CreateOctKeyOptions keyOptions = new CreateOctKeyOptions(NAME)
+                .setHardwareProtected(true)
+                .setKeyOperations(KeyOperation.ENCRYPT, KeyOperation.WRAP_KEY, KeyOperation.DECRYPT, KeyOperation.UNWRAP_KEY);
+        final KeyVaultKey key = keyClient.createOctKey(keyOptions);
+        Assertions.assertNotNull(key);
+        Assertions.assertTrue(key.getId().startsWith(vaultUrl), "Key Id should start with vault URL '" + vaultUrl + "'");
+
+        final CryptographyClient cryptographyClient = new CryptographyClientBuilder()
+                .keyIdentifier(key.getId())
+                .credential(credential)
+                .httpClient(httpClient)
+                .serviceVersion(CryptographyServiceVersion.V7_3)
+                .disableChallengeResourceVerification()
+                .retryPolicy(new RetryPolicy(new FixedDelay(0, Duration.ZERO)))
+                .buildClient();
+
+        final String testMessage = "test";
+        final EncryptParameters encryptParameters = EncryptParameters.createA128CbcParameters(
+                testMessage.getBytes(StandardCharsets.UTF_8), "iv-parameter-val".getBytes(StandardCharsets.UTF_8));
+        final EncryptResult encrypted = cryptographyClient
+                .encrypt(encryptParameters, Context.NONE);
+        final DecryptParameters decryptParameters = DecryptParameters
+                .createA128CbcParameters(encrypted.getCipherText(), encrypted.getIv());
+        final DecryptResult decrypted = cryptographyClient
+                .decrypt(decryptParameters, Context.NONE);
+
+        Assertions.assertEquals(testMessage, new String(decrypted.getPlainText(), StandardCharsets.UTF_8));
     }
 
     protected void verifyTokenEndpointIsWorking(final String endpointUrl, final HttpClient httpClient) {

--- a/lowkey-vault-testcontainers/src/test/java/com/github/nagyesta/lowkeyvault/testcontainers/LowkeyVaultArgLineBuilderTest.java
+++ b/lowkey-vault-testcontainers/src/test/java/com/github/nagyesta/lowkeyvault/testcontainers/LowkeyVaultArgLineBuilderTest.java
@@ -38,115 +38,136 @@ class LowkeyVaultArgLineBuilderTest {
     void testVaultNamesShouldSetArgumentWhenCalledWithValidData(final String name) {
         //given
         final LowkeyVaultArgLineBuilder underTest = new LowkeyVaultArgLineBuilder();
+        final List<String> expected = List.of(
+                "--LOWKEY_VAULT_RELAXED_PORTS=true",
+                "--LOWKEY_VAULT_NAMES=" + name);
 
         //when
         final List<String> actual = underTest.vaultNames(Set.of(name)).build();
 
         //then
-        Assertions.assertIterableEquals(List.of("--LOWKEY_VAULT_NAMES=" + name), actual);
+        Assertions.assertIterableEquals(expected, actual);
     }
 
     @Test
     void testLogicalHostShouldNotSetValueWhenCalledWithNull() {
         //given
         final LowkeyVaultArgLineBuilder underTest = new LowkeyVaultArgLineBuilder();
+        final List<String> expected = List.of("--LOWKEY_VAULT_RELAXED_PORTS=true");
 
         //when
         final List<String> actual = underTest.logicalHost(null).build();
 
         //then
-        Assertions.assertIterableEquals(List.of(), actual);
+        Assertions.assertIterableEquals(expected, actual);
     }
 
     @Test
     void testLogicalHostShouldSetArgumentWhenCalledWithValidData() {
         //given
         final LowkeyVaultArgLineBuilder underTest = new LowkeyVaultArgLineBuilder();
+        final List<String> expected = List.of(
+                "--LOWKEY_VAULT_RELAXED_PORTS=true",
+                "--LOWKEY_IMPORT_TEMPLATE_HOST=127.0.0.1");
 
         //when
         final List<String> actual = underTest.logicalHost("127.0.0.1").build();
 
         //then
-        Assertions.assertIterableEquals(List.of("--LOWKEY_IMPORT_TEMPLATE_HOST=127.0.0.1"), actual);
+        Assertions.assertIterableEquals(expected, actual);
     }
 
     @Test
     void testLogicalPortShouldNotSetValueWhenCalledWithNull() {
         //given
         final LowkeyVaultArgLineBuilder underTest = new LowkeyVaultArgLineBuilder();
+        final List<String> expected = List.of("--LOWKEY_VAULT_RELAXED_PORTS=true");
 
         //when
         final List<String> actual = underTest.logicalPort(null).build();
 
         //then
-        Assertions.assertIterableEquals(List.of(), actual);
+        Assertions.assertIterableEquals(expected, actual);
     }
 
     @Test
     void testLogicalPortShouldSetArgumentWhenCalledWithValidData() {
         //given
         final LowkeyVaultArgLineBuilder underTest = new LowkeyVaultArgLineBuilder();
+        final List<String> expected = List.of(
+                "--LOWKEY_VAULT_RELAXED_PORTS=true",
+                "--LOWKEY_IMPORT_TEMPLATE_PORT=1");
 
         //when
         final List<String> actual = underTest.logicalPort(1).build();
 
         //then
-        Assertions.assertIterableEquals(List.of("--LOWKEY_IMPORT_TEMPLATE_PORT=1"), actual);
+        Assertions.assertIterableEquals(expected, actual);
     }
 
     @Test
     void testDebugShouldNotSetValueWhenCalledWithFalse() {
         //given
         final LowkeyVaultArgLineBuilder underTest = new LowkeyVaultArgLineBuilder();
+        final List<String> expected = List.of("--LOWKEY_VAULT_RELAXED_PORTS=true");
 
         //when
         final List<String> actual = underTest.debug(false).build();
 
         //then
-        Assertions.assertIterableEquals(List.of(), actual);
+        Assertions.assertIterableEquals(expected, actual);
     }
 
     @Test
     void testDebugShouldSetArgumentWhenCalledWithTrue() {
         //given
         final LowkeyVaultArgLineBuilder underTest = new LowkeyVaultArgLineBuilder();
+        final List<String> expected = List.of(
+                "--LOWKEY_VAULT_RELAXED_PORTS=true",
+                "--LOWKEY_DEBUG_REQUEST_LOG=true");
 
         //when
         final List<String> actual = underTest.debug(true).build();
 
         //then
-        Assertions.assertIterableEquals(List.of("--LOWKEY_DEBUG_REQUEST_LOG=true"), actual);
+        Assertions.assertIterableEquals(expected, actual);
     }
 
     @Test
     void testImportFileShouldSetArgumentWhenCalledWithFile() {
         //given
         final LowkeyVaultArgLineBuilder underTest = new LowkeyVaultArgLineBuilder();
+        final List<String> expected = List.of(
+                "--LOWKEY_VAULT_RELAXED_PORTS=true",
+                "--LOWKEY_IMPORT_LOCATION=/import/vaults.json");
 
         //when
         final List<String> actual = underTest.importFile(new File(".")).build();
 
         //then
-        Assertions.assertIterableEquals(List.of("--LOWKEY_IMPORT_LOCATION=/import/vaults.json"), actual);
+        Assertions.assertIterableEquals(expected, actual);
     }
 
     @Test
     void testImportFileShouldNotSetArgumentWhenCalledWithNull() {
         //given
         final LowkeyVaultArgLineBuilder underTest = new LowkeyVaultArgLineBuilder();
+        final List<String> expected = List.of("--LOWKEY_VAULT_RELAXED_PORTS=true");
 
         //when
         final List<String> actual = underTest.importFile(null).build();
 
         //then
-        Assertions.assertIterableEquals(List.of(), actual);
+        Assertions.assertIterableEquals(expected, actual);
     }
 
     @Test
     void testCustomSslCertificateShouldSetArgumentWhenCalledWithValidFile() {
         //given
         final LowkeyVaultArgLineBuilder underTest = new LowkeyVaultArgLineBuilder();
-        final List<String> expected = List.of("--server.ssl.key-store=/config/cert.store",
+        final List<String> expected = List.of(
+                "--LOWKEY_VAULT_RELAXED_PORTS=true",
+                "--server.ssl.key-store=/config/cert.store",
                 "--server.ssl.key-store-type=JKS",
                 "--server.ssl.key-store-password=pass");
 
@@ -161,12 +182,13 @@ class LowkeyVaultArgLineBuilderTest {
     void testCustomSslCertificateShouldNotSetArgumentWhenCalledWithNull() {
         //given
         final LowkeyVaultArgLineBuilder underTest = new LowkeyVaultArgLineBuilder();
+        final List<String> expected = List.of("--LOWKEY_VAULT_RELAXED_PORTS=true");
 
         //when
         final List<String> actual = underTest.customSSLCertificate(null, "pass", StoreType.JKS).build();
 
         //then
-        Assertions.assertIterableEquals(List.of(), actual);
+        Assertions.assertIterableEquals(expected, actual);
     }
 
     @Test
@@ -176,10 +198,12 @@ class LowkeyVaultArgLineBuilderTest {
         final Map<String, Set<String>> aliases = new TreeMap<>(Map.of(
                 "localhost", new TreeSet<>(Set.of("alias.localhost", "alias.localhost:<port>")),
                 "lowkey-vault", Set.of("alias.localhost:30443")));
-        final List<String> expected = List.of("--LOWKEY_VAULT_ALIASES="
-                + "localhost=alias.localhost,"
-                + "localhost=alias.localhost:<port>,"
-                + "lowkey-vault=alias.localhost:30443"
+        final List<String> expected = List.of(
+                "--LOWKEY_VAULT_RELAXED_PORTS=true",
+                "--LOWKEY_VAULT_ALIASES="
+                        + "localhost=alias.localhost,"
+                        + "localhost=alias.localhost:<port>,"
+                        + "lowkey-vault=alias.localhost:30443"
         );
 
         //when
@@ -194,26 +218,30 @@ class LowkeyVaultArgLineBuilderTest {
     void testAliasesShouldNotSetArgumentWhenCalledWithNullOrEmptyMap(final Map<String, Set<String>> map) {
         //given
         final LowkeyVaultArgLineBuilder underTest = new LowkeyVaultArgLineBuilder();
+        final List<String> expected = List.of("--LOWKEY_VAULT_RELAXED_PORTS=true");
 
         //when
         final List<String> actual = underTest.aliases(map).build();
 
         //then
-        Assertions.assertIterableEquals(List.of(), actual);
+        Assertions.assertIterableEquals(expected, actual);
     }
 
     @Test
     void testAdditionalArgsShouldSetArgumentWhenCalledWithValidMap() {
         //given
         final LowkeyVaultArgLineBuilder underTest = new LowkeyVaultArgLineBuilder();
-        final List<String> expected = List.of("--LOWKEY_VAULT_ALIASES=\""
+        final String additional = "--LOWKEY_VAULT_ALIASES=\""
                 + "localhost=alias.localhost,"
                 + "localhost=alias.localhost:<port>,"
                 + "lowkey-vault=alias.localhost:30443"
-                + "\"");
+                + "\"";
+        final List<String> expected = List.of(
+                "--LOWKEY_VAULT_RELAXED_PORTS=true",
+                additional);
 
         //when
-        final List<String> actual = underTest.additionalArgs(expected).build();
+        final List<String> actual = underTest.additionalArgs(List.of(additional)).build();
 
         //then
         Assertions.assertIterableEquals(expected, actual);
@@ -224,11 +252,12 @@ class LowkeyVaultArgLineBuilderTest {
     void testAdditionalArgsShouldNotSetArgumentWhenCalledWithNullOrEmptyMap(final List<String> list) {
         //given
         final LowkeyVaultArgLineBuilder underTest = new LowkeyVaultArgLineBuilder();
+        final List<String> expected = List.of("--LOWKEY_VAULT_RELAXED_PORTS=true");
 
         //when
         final List<String> actual = underTest.additionalArgs(list).build();
 
         //then
-        Assertions.assertIterableEquals(List.of(), actual);
+        Assertions.assertIterableEquals(expected, actual);
     }
 }

--- a/lowkey-vault-testcontainers/src/test/java/com/github/nagyesta/lowkeyvault/testcontainers/LowkeyVaultContainerVanillaTest.java
+++ b/lowkey-vault-testcontainers/src/test/java/com/github/nagyesta/lowkeyvault/testcontainers/LowkeyVaultContainerVanillaTest.java
@@ -88,6 +88,7 @@ class LowkeyVaultContainerVanillaTest extends AbstractLowkeyVaultContainerTest {
         verifyConnectionIsWorking(endpoint, httpClient, credentials);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     void testContainerShouldStartUpWhenCalledWithFixedHostPort() {
         //given
@@ -193,7 +194,7 @@ class LowkeyVaultContainerVanillaTest extends AbstractLowkeyVaultContainerTest {
         underTest.start();
 
         //then
-        final String authority = EXAMPLE_COM + ":" + DEFAULT_PORT;
+        final String authority = EXAMPLE_COM + ":" + underTest.getMappedPort(DEFAULT_PORT);
         final String endpoint = "https://" + authority;
         final AuthorityOverrideFunction authorityOverrideFunction = new AuthorityOverrideFunction(
                 authority,
@@ -248,6 +249,7 @@ class LowkeyVaultContainerVanillaTest extends AbstractLowkeyVaultContainerTest {
         //then + exceptions
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     void testBuilderShouldThrowExceptionWhenCalledWithInvalidHostPortNumber() {
         //given


### PR DESCRIPTION
__Issue:__ #1319

### Description
<!-- A short summary of changes -->

- Adds new configuration option to allow relaxed matching of vault URI ports
- Updates tests
- Deprecates Testcontainers method setting a fixed host port
- Enhances Testcontainers module to always use the relaxed matching feature
- Adds more verification steps to Testcontainers tests
- Updates documentation

### Entry point
<!-- Where should the reviewer start in order to properly understand the PR? -->

-

### Checklists

- [x] I have rebased my branch
- [x] My commit message is meaningful
- [x] The commit messages use semantic versioning: ```{major}```, ```{minor}``` or ```{patch}```
- [x] The changes are focusing on the issue at hand
- [x] I have maintained or increased test coverage

### Notes

-
<!-- Any additional remarks you may have. -->
