### PR TITLE
Key operations are not persisted

### DIFF
--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/controller/common/BaseBackupRestoreController.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/controller/common/BaseBackupRestoreController.java
@@ -49,9 +49,10 @@ public abstract class BaseBackupRestoreController<K extends EntityId, V extends 
         R extends BaseEntityConverterRegistry<K, V, E, M, DM, PM, I, DI, BLI, BL, B>>
         extends GenericEntityController<K, V, E, M, DM, I, DI, MC, IC, VIC, S, PM, BLI, BL, B, R> {
 
-    protected BaseBackupRestoreController(@NonNull final R registry,
-                                          @NonNull final VaultService vaultService,
-                                          @NonNull final Function<VaultFake, S> toEntityVault) {
+    protected BaseBackupRestoreController(
+            @NonNull final R registry,
+            @NonNull final VaultService vaultService,
+            @NonNull final Function<VaultFake, S> toEntityVault) {
         super(registry, vaultService, toEntityVault);
     }
 

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/certificate/impl/CertificateImportInput.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/certificate/impl/CertificateImportInput.java
@@ -16,6 +16,7 @@ import java.security.cert.X509Certificate;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Consumer;
 
 import static com.github.nagyesta.lowkeyvault.service.certificate.CertificateLifetimeActionActivity.EMAIL_CONTACTS;
@@ -43,6 +44,10 @@ public class CertificateImportInput {
         this.keyData = contentType.getKey(certificateContent, password);
         this.policyModel = policyModel;
         this.parsedCertificateData = parsedInputBuilder(name, contentType, certificate, keyData, policyModel).build();
+        this.keyData.setKeyOps(this.parsedCertificateData.getKeyUsage().stream()
+                .map(KeyUsageEnum::getKeyOperations)
+                .flatMap(Set::stream)
+                .distinct().sorted().toList());
         this.certificateData = mergePolicies(this.parsedCertificateData, policyModel);
         final CertAuthorityType certAuthorityType = Optional.ofNullable(policyModel.getIssuer())
                 .map(IssuerParameterModel::getIssuer)

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/certificate/impl/KeyUsageEnum.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/certificate/impl/KeyUsageEnum.java
@@ -3,6 +3,7 @@ package com.github.nagyesta.lowkeyvault.service.certificate.impl;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.github.nagyesta.lowkeyvault.model.v7_2.key.constants.KeyOperation;
 import org.bouncycastle.asn1.x509.KeyUsage;
 
 import java.util.Arrays;
@@ -21,48 +22,50 @@ public enum KeyUsageEnum {
     /**
      * Digital signature key usage.
      */
-    DIGITAL_SIGNATURE("digitalSignature", KeyUsage.digitalSignature, 0),
+    DIGITAL_SIGNATURE("digitalSignature", KeyUsage.digitalSignature, 0, KeyOps.SIGN_VERIFY),
     /**
      * Non repudiation key usage.
      */
-    NON_REPUDIATION("nonRepudiation", KeyUsage.nonRepudiation, 1),
+    NON_REPUDIATION("nonRepudiation", KeyUsage.nonRepudiation, 1, KeyOps.SIGN_VERIFY),
     /**
      * Key encipherment key usage.
      */
-    KEY_ENCIPHERMENT("keyEncipherment", KeyUsage.keyEncipherment, 2),
+    KEY_ENCIPHERMENT("keyEncipherment", KeyUsage.keyEncipherment, 2, KeyOps.ENCRYPT_DECRYPT),
     /**
      * Data encipherment key usage.
      */
-    DATA_ENCIPHERMENT("dataEncipherment", KeyUsage.dataEncipherment, 3),
+    DATA_ENCIPHERMENT("dataEncipherment", KeyUsage.dataEncipherment, 3, KeyOps.ENCRYPT_DECRYPT),
     /**
      * Key agreement key usage.
      */
-    KEY_AGREEMENT("keyAgreement", KeyUsage.keyAgreement, 4),
+    KEY_AGREEMENT("keyAgreement", KeyUsage.keyAgreement, 4, KeyOps.SIGN_VERIFY),
     /**
      * Key certificate sign key usage.
      */
-    KEY_CERT_SIGN("keyCertSign", KeyUsage.keyCertSign, 5),
+    KEY_CERT_SIGN("keyCertSign", KeyUsage.keyCertSign, 5, KeyOps.SIGN_VERIFY),
     /**
      * CRL sign key usage.
      */
-    CRL_SIGN("cRLSign", KeyUsage.cRLSign, 6),
+    CRL_SIGN("cRLSign", KeyUsage.cRLSign, 6, KeyOps.SIGN_VERIFY),
     /**
      * Encipher only key usage.
      */
-    ENCIPHER_ONLY("encipherOnly", KeyUsage.encipherOnly, 7),
+    ENCIPHER_ONLY("encipherOnly", KeyUsage.encipherOnly, 7, KeyOps.ENCRYPT_DECRYPT),
     /**
      * Decipher only key usage.
      */
-    DECIPHER_ONLY("decipherOnly", KeyUsage.decipherOnly, 8);
+    DECIPHER_ONLY("decipherOnly", KeyUsage.decipherOnly, 8, KeyOps.ENCRYPT_DECRYPT);
 
     private final String value;
     private final int code;
     private final int position;
+    private final Set<KeyOperation> keyOperations;
 
-    KeyUsageEnum(final String value, final int code, final int position) {
+    KeyUsageEnum(final String value, final int code, final int position, final Set<KeyOperation> keyOperations) {
         this.value = value;
         this.code = code;
         this.position = position;
+        this.keyOperations = Set.copyOf(keyOperations);
     }
 
     @JsonValue
@@ -73,6 +76,11 @@ public enum KeyUsageEnum {
     @JsonIgnore
     public int getCode() {
         return code;
+    }
+
+    @JsonIgnore
+    public Set<KeyOperation> getKeyOperations() {
+        return keyOperations;
     }
 
     @JsonIgnore
@@ -121,5 +129,12 @@ public enum KeyUsageEnum {
         public Set<Characteristics> characteristics() {
             return Set.of(Characteristics.UNORDERED);
         }
+    }
+
+    private static final class KeyOps {
+        public static final Set<KeyOperation>
+                SIGN_VERIFY = Set.of(KeyOperation.SIGN, KeyOperation.VERIFY);
+        public static final Set<KeyOperation>
+                ENCRYPT_DECRYPT = Set.of(KeyOperation.ENCRYPT, KeyOperation.DECRYPT, KeyOperation.WRAP_KEY, KeyOperation.UNWRAP_KEY);
     }
 }

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/certificate/impl/KeyVaultCertificateEntity.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/service/certificate/impl/KeyVaultCertificateEntity.java
@@ -43,6 +43,7 @@ public class KeyVaultCertificateEntity
     private final String originalCertificateContents;
     private CertificatePolicy issuancePolicy;
     private PKCS10CertificationRequest csr;
+
     /**
      * Constructor for certificate creation.
      *
@@ -50,9 +51,10 @@ public class KeyVaultCertificateEntity
      * @param input The input parameters.
      * @param vault The vault we need to use.
      */
-    public KeyVaultCertificateEntity(@NonNull final String name,
-                                     @NonNull final CertificateCreationInput input,
-                                     @org.springframework.lang.NonNull final VaultFake vault) {
+    public KeyVaultCertificateEntity(
+            @NonNull final String name,
+            @NonNull final CertificateCreationInput input,
+            @org.springframework.lang.NonNull final VaultFake vault) {
         super(vault);
         Assert.state(name.equals(input.getName()),
                 "Certificate name (" + name + ") did not match name from certificate creation input: " + input.getName());
@@ -82,9 +84,10 @@ public class KeyVaultCertificateEntity
      * @param input The input parameters.
      * @param vault The vault we need to use.
      */
-    public KeyVaultCertificateEntity(@NonNull final String name,
-                                     @NonNull final CertificateImportInput input,
-                                     @org.springframework.lang.NonNull final VaultFake vault) {
+    public KeyVaultCertificateEntity(
+            @NonNull final String name,
+            @NonNull final CertificateImportInput input,
+            @org.springframework.lang.NonNull final VaultFake vault) {
         super(vault);
         final ReadOnlyCertificatePolicy policy = Optional.ofNullable(input.getCertificateData())
                 .orElseThrow(() -> new IllegalArgumentException("Certificate data must not be null."));
@@ -122,10 +125,11 @@ public class KeyVaultCertificateEntity
      * @param id    The ID of the new certificate entity.
      * @param vault The vault we are using.
      */
-    public KeyVaultCertificateEntity(@NonNull final ReadOnlyCertificatePolicy input,
-                                     @NonNull final VersionedKeyEntityId kid,
-                                     @NonNull final VersionedCertificateEntityId id,
-                                     @org.springframework.lang.NonNull final VaultFake vault) {
+    public KeyVaultCertificateEntity(
+            @NonNull final ReadOnlyCertificatePolicy input,
+            @NonNull final VersionedKeyEntityId kid,
+            @NonNull final VersionedCertificateEntityId id,
+            @org.springframework.lang.NonNull final VaultFake vault) {
         super(vault);
         Assert.state(vault.keyVaultFake().getEntities().containsEntity(kid),
                 "Key must exist to be able to renew certificate using it. " + kid.asUriNoVersion(vault.baseUri()));
@@ -150,13 +154,14 @@ public class KeyVaultCertificateEntity
     /**
      * Constructor for certificate restore.
      *
-     * @param id  The id of the certificate entity.
+     * @param id    The id of the certificate entity.
      * @param input The input parameters.
      * @param vault The vault we need to use.
      */
-    public KeyVaultCertificateEntity(@NonNull final VersionedCertificateEntityId id,
-                                     @NonNull final CertificateRestoreInput input,
-                                     @org.springframework.lang.NonNull final VaultFake vault) {
+    public KeyVaultCertificateEntity(
+            @NonNull final VersionedCertificateEntityId id,
+            @NonNull final CertificateRestoreInput input,
+            @org.springframework.lang.NonNull final VaultFake vault) {
         super(vault);
         final ReadOnlyCertificatePolicy policy = input.getCertificateData();
         final ReadOnlyCertificatePolicy originalCertificateData = input.getParsedCertificateData();

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/TestConstantsCertificates.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/TestConstantsCertificates.java
@@ -1,7 +1,12 @@
 package com.github.nagyesta.lowkeyvault;
 
+import com.github.nagyesta.lowkeyvault.model.v7_2.key.constants.KeyOperation;
 import com.github.nagyesta.lowkeyvault.service.certificate.id.CertificateEntityId;
 import com.github.nagyesta.lowkeyvault.service.certificate.id.VersionedCertificateEntityId;
+import com.github.nagyesta.lowkeyvault.service.certificate.impl.KeyUsageEnum;
+
+import java.util.List;
+import java.util.Set;
 
 import static com.github.nagyesta.lowkeyvault.TestConstantsUri.HTTPS_LOCALHOST_8443;
 import static com.github.nagyesta.lowkeyvault.TestConstantsUri.HTTPS_LOWKEY_VAULT;
@@ -12,6 +17,30 @@ public final class TestConstantsCertificates {
     private TestConstantsCertificates() {
         throw new IllegalCallerException("Utility.");
     }
+
+    public static final int VALIDITY_MONTHS_ONE_YEAR = 12;
+    public static final int VALIDITY_TEN_MONTHS = 10;
+
+    public static final Set<String> EXTENDED_KEY_USAGE = Set.of("1.3.6.1.5.5.7.3.1");
+    public static final String CN_TEST = "CN=Test";
+    public static final String SELF = "Self";
+    public static final boolean CERT_TRANSPARENCY = false;
+    public static final String SELF_SIGNED = "SelfSigned";
+    public static final boolean ENABLED = true;
+    public static final boolean REUSE_KEY = true;
+    public static final boolean EXPORTABLE = true;
+    public static final int SECONDS_IN_FIVE_DAYS = 5 * 24 * 60 * 60;
+    public static final String CERTIFICATE_BACKUP_TEST = "certificate-backup-test";
+    public static final Set<String> SANS_TEST_COM_AND_TEST2_COM = Set.of("test.com", "test2.com");
+    public static final Set<KeyUsageEnum> KEY_USAGE_ENCIPHER_ONLY_DECIPHER_ONLY = Set
+            .of(KeyUsageEnum.ENCIPHER_ONLY, KeyUsageEnum.DECIPHER_ONLY);
+    public static final List<KeyOperation> ALL_KEY_OPERATIONS = List.of(
+            KeyOperation.ENCRYPT,
+            KeyOperation.DECRYPT,
+            KeyOperation.SIGN,
+            KeyOperation.VERIFY,
+            KeyOperation.WRAP_KEY,
+            KeyOperation.UNWRAP_KEY);
 
     //<editor-fold defaultstate="collapsed" desc="Certificates">
     public static final String CERT_NAME_1 = "cert-name-01";

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/TestConstantsKeys.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/TestConstantsKeys.java
@@ -17,6 +17,8 @@ public final class TestConstantsKeys {
     //<editor-fold defaultstate="collapsed" desc="Crypto">
     public static final int MIN_RSA_KEY_SIZE = KeyType.RSA.validateOrDefault(null, Integer.class);
     public static final int MIN_AES_KEY_SIZE = KeyType.OCT.validateOrDefault(null, Integer.class);
+    public static final int AES_256 = 256;
+    public static final String SHA_256 = "SHA-256";
     //</editor-fold>
 
     //<editor-fold defaultstate="collapsed" desc="Keys">

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/controller/VaultBackupManagementControllerIntegrationTest.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/controller/VaultBackupManagementControllerIntegrationTest.java
@@ -38,6 +38,8 @@ import java.net.URI;
 import java.util.List;
 import java.util.Set;
 
+import static com.github.nagyesta.lowkeyvault.TestConstantsCertificates.ALL_KEY_OPERATIONS;
+
 @LaunchAbortArmed
 @SpringBootTest(properties = {"LOWKEY_VAULT_NAMES=-"}, classes = VaultBackupConfiguration.class)
 @ActiveProfiles("vault")
@@ -59,10 +61,13 @@ class VaultBackupManagementControllerIntegrationTest {
     private static final String CERTIFICATE_VERSION = "6ae160e0bddc486691653798e41abee0";
     private static final VersionedCertificateEntityId VERSIONED_CERTIFICATE_ENTITY_ID =
             new VersionedCertificateEntityId(BASE_URI, TEST_CERTIFICATE, CERTIFICATE_VERSION);
+    private static final VersionedKeyEntityId VERSIONED_CERTIFICATE_MANAGED_KEY_ENTITY_ID =
+            new VersionedKeyEntityId(BASE_URI, TEST_CERTIFICATE, CERTIFICATE_VERSION);
     private static final String SECRET_VALUE = "$3cret";
     private static final int EXPECTED_KEY_SIZE = 2048;
     private static final String EXPECTED_SANS = "*.example.com";
     private static final String EXPECTED_SUBJECT = "CN=example.com";
+
     @Autowired
     private VaultService vaultService;
     @Autowired
@@ -114,6 +119,11 @@ class VaultBackupManagementControllerIntegrationTest {
         Assertions.assertIterableEquals(Set.of(EXPECTED_SANS), certificatePolicy.getDnsNames());
         Assertions.assertEquals(EXPECTED_KEY_SIZE, certificatePolicy.getKeySize());
         Assertions.assertEquals(KeyType.RSA, certificatePolicy.getKeyType());
+        //- managed key
+        final ReadOnlyKeyVaultKeyEntity readOnlyKeyEntityManaged = keyVaultFake.getEntities()
+                .getReadOnlyEntity(VERSIONED_CERTIFICATE_MANAGED_KEY_ENTITY_ID);
+        Assertions.assertEquals(VERSIONED_CERTIFICATE_MANAGED_KEY_ENTITY_ID, readOnlyKeyEntityManaged.getId());
+        Assertions.assertIterableEquals(ALL_KEY_OPERATIONS, readOnlyKeyEntityManaged.getOperations());
     }
 
     @Test

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/controller/v7_2/KeyControllerIntegrationTest.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/controller/v7_2/KeyControllerIntegrationTest.java
@@ -35,15 +35,13 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.stream.Stream;
 
+import static com.github.nagyesta.lowkeyvault.TestConstantsKeys.*;
+
 @LaunchAbortArmed
 @SpringBootTest
 class KeyControllerIntegrationTest {
 
     private static final byte[] IV = "_iv-param-value_".getBytes(StandardCharsets.UTF_8);
-    private static final int AES_256 = 256;
-    private static final int RSA_2048 = 2048;
-    private static final String SHA_256 = "SHA-256";
-
     @Autowired
     private VaultService vaultService;
     @Autowired
@@ -101,7 +99,7 @@ class KeyControllerIntegrationTest {
         //then
         Assertions.assertNotNull(response);
         Assertions.assertNotNull(actual);
-        Assertions.assertEquals(RSA_2048, actual.getKeySize());
+        Assertions.assertEquals(MIN_RSA_KEY_SIZE, actual.getKeySize());
         final byte[] encrypted = actual.encryptBytes(name.getBytes(StandardCharsets.UTF_8), EncryptionAlgorithm.RSA_OAEP_256, null);
         final byte[] decrypted = actual.decryptToBytes(encrypted, EncryptionAlgorithm.RSA_OAEP_256, null);
         Assertions.assertEquals(name, new String(decrypted));

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/controller/v7_3/CertificateBackupRestoreControllerIntegrationTest.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/controller/v7_3/CertificateBackupRestoreControllerIntegrationTest.java
@@ -7,7 +7,6 @@ import com.github.nagyesta.lowkeyvault.model.v7_3.certificate.*;
 import com.github.nagyesta.lowkeyvault.service.certificate.CertificateLifetimeActionActivity;
 import com.github.nagyesta.lowkeyvault.service.certificate.id.CertificateEntityId;
 import com.github.nagyesta.lowkeyvault.service.certificate.impl.CertContentType;
-import com.github.nagyesta.lowkeyvault.service.certificate.impl.KeyUsageEnum;
 import com.github.nagyesta.lowkeyvault.service.key.ReadOnlyKeyVaultKeyEntity;
 import com.github.nagyesta.lowkeyvault.service.key.id.VersionedKeyEntityId;
 import com.github.nagyesta.lowkeyvault.service.secret.ReadOnlyKeyVaultSecretEntity;
@@ -31,25 +30,13 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static com.github.nagyesta.lowkeyvault.TestConstantsCertificates.*;
+import static com.github.nagyesta.lowkeyvault.TestConstantsKeys.MIN_RSA_KEY_SIZE;
 import static com.github.nagyesta.lowkeyvault.TestConstantsUri.getRandomVaultUri;
 
 @SpringBootTest
 class CertificateBackupRestoreControllerIntegrationTest {
 
-    private static final String CN_TEST = "CN=Test";
-    private static final int VALIDITY_MONTHS = 10;
-    private static final Set<String> EXTENDED_KEY_USAGE = Set.of("1.3.6.1.5.5.7.3.1");
-    private static final Set<KeyUsageEnum> KEY_USAGE = Set.of(KeyUsageEnum.ENCIPHER_ONLY, KeyUsageEnum.DECIPHER_ONLY);
-    private static final Set<String> SANS = Set.of("test.com", "test2.com");
-    private static final String SELF = "Self";
-    private static final boolean CERT_TRANSPARENCY = false;
-    private static final String SELF_SIGNED = "SelfSigned";
-    private static final boolean ENABLED = true;
-    private static final int KEY_SIZE = 2048;
-    private static final boolean REUSE_KEY = true;
-    private static final boolean EXPORTABLE = true;
-    private static final int SECONDS_IN_FIVE_DAYS = 5 * 24 * 60 * 60;
-    private static final String CERTIFICATE_BACKUP_TEST = "certificate-backup-test";
     @Autowired
     private VaultService vaultService;
     @Autowired
@@ -111,10 +98,10 @@ class CertificateBackupRestoreControllerIntegrationTest {
         final CertificatePolicyModel policy = new CertificatePolicyModel();
         final X509CertificateModel x509 = new X509CertificateModel();
         x509.setSubject(CN_TEST);
-        x509.setValidityMonths(VALIDITY_MONTHS);
-        x509.setKeyUsage(KEY_USAGE);
+        x509.setValidityMonths(VALIDITY_TEN_MONTHS);
+        x509.setKeyUsage(KEY_USAGE_ENCIPHER_ONLY_DECIPHER_ONLY);
         x509.setExtendedKeyUsage(EXTENDED_KEY_USAGE);
-        x509.setSubjectAlternativeNames(new SubjectAlternativeNames(SANS, Set.of(), Set.of()));
+        x509.setSubjectAlternativeNames(new SubjectAlternativeNames(SANS_TEST_COM_AND_TEST2_COM, Set.of(), Set.of()));
         policy.setX509Properties(x509);
 
         final IssuerParameterModel issuer = new IssuerParameterModel();
@@ -132,7 +119,7 @@ class CertificateBackupRestoreControllerIntegrationTest {
         policy.setSecretProperties(secret);
 
         final CertificateKeyModel key = new CertificateKeyModel();
-        key.setKeySize(KEY_SIZE);
+        key.setKeySize(MIN_RSA_KEY_SIZE);
         key.setReuseKey(REUSE_KEY);
         key.setKeyType(KeyType.RSA);
         key.setExportable(EXPORTABLE);

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/controller/v7_3/KeyControllerIntegrationTest.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/controller/v7_3/KeyControllerIntegrationTest.java
@@ -35,6 +35,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.stream.Stream;
 
+import static com.github.nagyesta.lowkeyvault.TestConstantsKeys.*;
 import static com.github.nagyesta.lowkeyvault.TestConstantsUri.getRandomVaultUri;
 
 @LaunchAbortArmed
@@ -42,9 +43,6 @@ import static com.github.nagyesta.lowkeyvault.TestConstantsUri.getRandomVaultUri
 class KeyControllerIntegrationTest {
 
     private static final byte[] IV = "_iv-param-value_".getBytes(StandardCharsets.UTF_8);
-    private static final int AES_256 = 256;
-    private static final int RSA_2048 = 2048;
-    private static final String SHA_256 = "SHA-256";
 
     @Autowired
     private VaultService vaultService;
@@ -105,7 +103,7 @@ class KeyControllerIntegrationTest {
         //then
         Assertions.assertNotNull(response);
         Assertions.assertNotNull(actual);
-        Assertions.assertEquals(RSA_2048, actual.getKeySize());
+        Assertions.assertEquals(MIN_RSA_KEY_SIZE, actual.getKeySize());
         final byte[] encrypted = actual.encryptBytes(name.getBytes(StandardCharsets.UTF_8), EncryptionAlgorithm.RSA_OAEP_256, null);
         final byte[] decrypted = actual.decryptToBytes(encrypted, EncryptionAlgorithm.RSA_OAEP_256, null);
         Assertions.assertEquals(name, new String(decrypted));

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/controller/v7_4/CertificateBackupRestoreControllerIntegrationTest.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/controller/v7_4/CertificateBackupRestoreControllerIntegrationTest.java
@@ -7,7 +7,6 @@ import com.github.nagyesta.lowkeyvault.model.v7_3.certificate.*;
 import com.github.nagyesta.lowkeyvault.service.certificate.CertificateLifetimeActionActivity;
 import com.github.nagyesta.lowkeyvault.service.certificate.id.CertificateEntityId;
 import com.github.nagyesta.lowkeyvault.service.certificate.impl.CertContentType;
-import com.github.nagyesta.lowkeyvault.service.certificate.impl.KeyUsageEnum;
 import com.github.nagyesta.lowkeyvault.service.key.ReadOnlyKeyVaultKeyEntity;
 import com.github.nagyesta.lowkeyvault.service.key.id.VersionedKeyEntityId;
 import com.github.nagyesta.lowkeyvault.service.secret.ReadOnlyKeyVaultSecretEntity;
@@ -31,25 +30,13 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static com.github.nagyesta.lowkeyvault.TestConstantsCertificates.*;
+import static com.github.nagyesta.lowkeyvault.TestConstantsKeys.MIN_RSA_KEY_SIZE;
 import static com.github.nagyesta.lowkeyvault.TestConstantsUri.getRandomVaultUri;
 
 @SpringBootTest
 class CertificateBackupRestoreControllerIntegrationTest {
 
-    private static final String CN_TEST = "CN=Test";
-    private static final int VALIDITY_MONTHS = 10;
-    private static final Set<String> EXTENDED_KEY_USAGE = Set.of("1.3.6.1.5.5.7.3.1");
-    private static final Set<KeyUsageEnum> KEY_USAGE = Set.of(KeyUsageEnum.ENCIPHER_ONLY, KeyUsageEnum.DECIPHER_ONLY);
-    private static final Set<String> SANS = Set.of("test.com", "test2.com");
-    private static final String SELF = "Self";
-    private static final boolean CERT_TRANSPARENCY = false;
-    private static final String SELF_SIGNED = "SelfSigned";
-    private static final boolean ENABLED = true;
-    private static final int KEY_SIZE = 2048;
-    private static final boolean REUSE_KEY = true;
-    private static final boolean EXPORTABLE = true;
-    private static final int SECONDS_IN_FIVE_DAYS = 5 * 24 * 60 * 60;
-    private static final String CERTIFICATE_BACKUP_TEST = "certificate-backup-test";
     @Autowired
     private VaultService vaultService;
     @Autowired
@@ -111,10 +98,10 @@ class CertificateBackupRestoreControllerIntegrationTest {
         final CertificatePolicyModel policy = new CertificatePolicyModel();
         final X509CertificateModel x509 = new X509CertificateModel();
         x509.setSubject(CN_TEST);
-        x509.setValidityMonths(VALIDITY_MONTHS);
-        x509.setKeyUsage(KEY_USAGE);
+        x509.setValidityMonths(VALIDITY_TEN_MONTHS);
+        x509.setKeyUsage(KEY_USAGE_ENCIPHER_ONLY_DECIPHER_ONLY);
         x509.setExtendedKeyUsage(EXTENDED_KEY_USAGE);
-        x509.setSubjectAlternativeNames(new SubjectAlternativeNames(SANS, Set.of(), Set.of()));
+        x509.setSubjectAlternativeNames(new SubjectAlternativeNames(SANS_TEST_COM_AND_TEST2_COM, Set.of(), Set.of()));
         policy.setX509Properties(x509);
 
         final IssuerParameterModel issuer = new IssuerParameterModel();
@@ -132,7 +119,7 @@ class CertificateBackupRestoreControllerIntegrationTest {
         policy.setSecretProperties(secret);
 
         final CertificateKeyModel key = new CertificateKeyModel();
-        key.setKeySize(KEY_SIZE);
+        key.setKeySize(MIN_RSA_KEY_SIZE);
         key.setReuseKey(REUSE_KEY);
         key.setKeyType(KeyType.RSA);
         key.setExportable(EXPORTABLE);

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/controller/v7_4/KeyControllerIntegrationTest.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/controller/v7_4/KeyControllerIntegrationTest.java
@@ -35,6 +35,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.stream.Stream;
 
+import static com.github.nagyesta.lowkeyvault.TestConstantsKeys.*;
 import static com.github.nagyesta.lowkeyvault.TestConstantsUri.getRandomVaultUri;
 
 @LaunchAbortArmed
@@ -42,9 +43,6 @@ import static com.github.nagyesta.lowkeyvault.TestConstantsUri.getRandomVaultUri
 class KeyControllerIntegrationTest {
 
     private static final byte[] IV = "_iv-param-value_".getBytes(StandardCharsets.UTF_8);
-    private static final int AES_256 = 256;
-    private static final int RSA_2048 = 2048;
-    private static final String SHA_256 = "SHA-256";
 
     @Autowired
     private VaultService vaultService;
@@ -105,7 +103,7 @@ class KeyControllerIntegrationTest {
         //then
         Assertions.assertNotNull(response);
         Assertions.assertNotNull(actual);
-        Assertions.assertEquals(RSA_2048, actual.getKeySize());
+        Assertions.assertEquals(MIN_RSA_KEY_SIZE, actual.getKeySize());
         final byte[] encrypted = actual.encryptBytes(name.getBytes(StandardCharsets.UTF_8), EncryptionAlgorithm.RSA_OAEP_256, null);
         final byte[] decrypted = actual.decryptToBytes(encrypted, EncryptionAlgorithm.RSA_OAEP_256, null);
         Assertions.assertEquals(name, new String(decrypted));

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/controller/v7_5/CertificateBackupRestoreControllerIntegrationTest.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/controller/v7_5/CertificateBackupRestoreControllerIntegrationTest.java
@@ -7,7 +7,6 @@ import com.github.nagyesta.lowkeyvault.model.v7_3.certificate.*;
 import com.github.nagyesta.lowkeyvault.service.certificate.CertificateLifetimeActionActivity;
 import com.github.nagyesta.lowkeyvault.service.certificate.id.CertificateEntityId;
 import com.github.nagyesta.lowkeyvault.service.certificate.impl.CertContentType;
-import com.github.nagyesta.lowkeyvault.service.certificate.impl.KeyUsageEnum;
 import com.github.nagyesta.lowkeyvault.service.key.ReadOnlyKeyVaultKeyEntity;
 import com.github.nagyesta.lowkeyvault.service.key.id.VersionedKeyEntityId;
 import com.github.nagyesta.lowkeyvault.service.secret.ReadOnlyKeyVaultSecretEntity;
@@ -31,25 +30,13 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static com.github.nagyesta.lowkeyvault.TestConstantsCertificates.*;
+import static com.github.nagyesta.lowkeyvault.TestConstantsKeys.MIN_RSA_KEY_SIZE;
 import static com.github.nagyesta.lowkeyvault.TestConstantsUri.getRandomVaultUri;
 
 @SpringBootTest
 class CertificateBackupRestoreControllerIntegrationTest {
 
-    private static final String CN_TEST = "CN=Test";
-    private static final int VALIDITY_MONTHS = 10;
-    private static final Set<String> EXTENDED_KEY_USAGE = Set.of("1.3.6.1.5.5.7.3.1");
-    private static final Set<KeyUsageEnum> KEY_USAGE = Set.of(KeyUsageEnum.ENCIPHER_ONLY, KeyUsageEnum.DECIPHER_ONLY);
-    private static final Set<String> SANS = Set.of("test.com", "test2.com");
-    private static final String SELF = "Self";
-    private static final boolean CERT_TRANSPARENCY = false;
-    private static final String SELF_SIGNED = "SelfSigned";
-    private static final boolean ENABLED = true;
-    private static final int KEY_SIZE = 2048;
-    private static final boolean REUSE_KEY = true;
-    private static final boolean EXPORTABLE = true;
-    private static final int SECONDS_IN_FIVE_DAYS = 5 * 24 * 60 * 60;
-    private static final String CERTIFICATE_BACKUP_TEST = "certificate-backup-test";
     @Autowired
     private VaultService vaultService;
     @Autowired
@@ -111,10 +98,10 @@ class CertificateBackupRestoreControllerIntegrationTest {
         final CertificatePolicyModel policy = new CertificatePolicyModel();
         final X509CertificateModel x509 = new X509CertificateModel();
         x509.setSubject(CN_TEST);
-        x509.setValidityMonths(VALIDITY_MONTHS);
-        x509.setKeyUsage(KEY_USAGE);
+        x509.setValidityMonths(VALIDITY_TEN_MONTHS);
+        x509.setKeyUsage(KEY_USAGE_ENCIPHER_ONLY_DECIPHER_ONLY);
         x509.setExtendedKeyUsage(EXTENDED_KEY_USAGE);
-        x509.setSubjectAlternativeNames(new SubjectAlternativeNames(SANS, Set.of(), Set.of()));
+        x509.setSubjectAlternativeNames(new SubjectAlternativeNames(SANS_TEST_COM_AND_TEST2_COM, Set.of(), Set.of()));
         policy.setX509Properties(x509);
 
         final IssuerParameterModel issuer = new IssuerParameterModel();
@@ -132,7 +119,7 @@ class CertificateBackupRestoreControllerIntegrationTest {
         policy.setSecretProperties(secret);
 
         final CertificateKeyModel key = new CertificateKeyModel();
-        key.setKeySize(KEY_SIZE);
+        key.setKeySize(MIN_RSA_KEY_SIZE);
         key.setReuseKey(REUSE_KEY);
         key.setKeyType(KeyType.RSA);
         key.setExportable(EXPORTABLE);

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/service/certificate/impl/CertContentTypeTest.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/service/certificate/impl/CertContentTypeTest.java
@@ -22,6 +22,7 @@ import java.util.Objects;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
+import static com.github.nagyesta.lowkeyvault.TestConstantsKeys.MIN_RSA_KEY_SIZE;
 import static com.github.nagyesta.lowkeyvault.service.certificate.impl.CertContentType.PEM;
 import static com.github.nagyesta.lowkeyvault.service.certificate.impl.CertContentType.PKCS12;
 import static org.mockito.Mockito.mock;
@@ -58,7 +59,6 @@ class CertContentTypeTest {
             /eGSDWHJ20KDyt98c7QJIjt87KIh3jd1WRzeRZ7YWWdRxigerYlupO2iFSr28seB\
             NjuCqPwdGwuYHGe/SskEqjVYxFoFknPhsn5Y64b1RuJe19qjewYl0NBmBjiEexY1\
             Tg/nnzqHPv4GAnWcp4e9IOAB00LfXwFj4D/lTOuGpdUFeIhjN0dx""";
-    private static final int KEY_SIZE = 2048;
     @SuppressWarnings("SpellCheckingInspection")
     private static final String MIME_BASE64 = """
             TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdCwg\r
@@ -446,7 +446,7 @@ class CertContentTypeTest {
     @Test
     void testCertificatePackageForBackupShouldThrowExceptionWhenCalledWithValidKeyAndNullCertificateUsingPkcs12Store() {
         //given
-        final KeyPair keyPair = KeyGenUtil.generateRsa(KEY_SIZE, null);
+        final KeyPair keyPair = KeyGenUtil.generateRsa(MIN_RSA_KEY_SIZE, null);
         final CertContentType underTest = PKCS12;
 
         //when
@@ -459,7 +459,7 @@ class CertContentTypeTest {
     void testCertificatePackageForBackupShouldThrowExceptionWhenCalledWithValidKeyAndInvalidCertificateUsingPkcs12Store() {
         //given
         final Certificate certificate = mock(Certificate.class);
-        final KeyPair keyPair = KeyGenUtil.generateRsa(KEY_SIZE, null);
+        final KeyPair keyPair = KeyGenUtil.generateRsa(MIN_RSA_KEY_SIZE, null);
         final CertContentType underTest = PKCS12;
 
         //when

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/service/certificate/impl/CertificateImportInputTest.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/service/certificate/impl/CertificateImportInputTest.java
@@ -15,6 +15,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import static com.github.nagyesta.lowkeyvault.TestConstantsCertificateKeys.*;
+import static com.github.nagyesta.lowkeyvault.TestConstantsCertificates.ALL_KEY_OPERATIONS;
 import static com.github.nagyesta.lowkeyvault.TestConstantsCertificates.CERT_NAME_1;
 
 class CertificateImportInputTest {
@@ -171,7 +172,7 @@ class CertificateImportInputTest {
 
         //then
         Assertions.assertEquals(KeyType.RSA, actual.getKeyData().getKeyType());
-        Assertions.assertIterableEquals(Set.of(), actual.getKeyData().getKeyOps());
+        Assertions.assertIterableEquals(ALL_KEY_OPERATIONS, actual.getKeyData().getKeyOps());
         Assertions.assertArrayEquals(RSA_KEY_E, actual.getKeyData().getE());
         Assertions.assertArrayEquals(RSA_KEY_N, actual.getKeyData().getN());
         Assertions.assertArrayEquals(RSA_KEY_D, actual.getKeyData().getD());
@@ -194,7 +195,7 @@ class CertificateImportInputTest {
 
         //then
         Assertions.assertEquals(KeyType.RSA, actual.getKeyData().getKeyType());
-        Assertions.assertIterableEquals(Set.of(), actual.getKeyData().getKeyOps());
+        Assertions.assertIterableEquals(ALL_KEY_OPERATIONS, actual.getKeyData().getKeyOps());
         Assertions.assertArrayEquals(RSA_KEY_E, actual.getKeyData().getE());
         Assertions.assertArrayEquals(RSA_KEY_N, actual.getKeyData().getN());
         Assertions.assertArrayEquals(RSA_KEY_D, actual.getKeyData().getD());

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/service/certificate/impl/CertificateVaultFakeImplTest.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/service/certificate/impl/CertificateVaultFakeImplTest.java
@@ -33,7 +33,6 @@ import static com.github.nagyesta.lowkeyvault.model.v7_2.common.constants.Recove
 import static com.github.nagyesta.lowkeyvault.service.certificate.CertificateLifetimeActionActivity.AUTO_RENEW;
 import static com.github.nagyesta.lowkeyvault.service.certificate.CertificateLifetimeActionTriggerType.DAYS_BEFORE_EXPIRY;
 import static com.github.nagyesta.lowkeyvault.service.certificate.impl.CertAuthorityType.UNKNOWN;
-import static com.github.nagyesta.lowkeyvault.service.certificate.impl.KeyVaultCertificateEntityTest.VALIDITY_MONTHS;
 import static org.mockito.Mockito.*;
 
 class CertificateVaultFakeImplTest {
@@ -103,9 +102,9 @@ class CertificateVaultFakeImplTest {
                 .keyType(KeyType.EC)
                 .keyCurveName(KeyCurveName.P_521)
                 .extendedKeyUsage(Set.of("1.3.6.1.5.5.7.3.1", "1.3.6.1.5.5.7.3.2"))
-                .keyUsage(Set.of(KeyUsageEnum.KEY_ENCIPHERMENT))
+                .keyUsage(Set.of(KeyUsageEnum.DIGITAL_SIGNATURE))
                 .reuseKeyOnRenewal(true)
-                .validityMonths(VALIDITY_MONTHS)
+                .validityMonths(VALIDITY_MONTHS_ONE_YEAR)
                 .exportablePrivateKey(true)
                 .build();
 
@@ -413,7 +412,7 @@ class CertificateVaultFakeImplTest {
                 .keyType(KeyType.EC)
                 .keyCurveName(KeyCurveName.P_256)
                 .validityStart(NOW)
-                .validityMonths(VALIDITY_MONTHS)
+                .validityMonths(VALIDITY_MONTHS_ONE_YEAR)
                 .contentType(CertContentType.PEM)
                 .build();
         when(vault.getRecoveryLevel()).thenReturn(RECOVERABLE_AND_PURGEABLE);

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/service/certificate/impl/KeyVaultCertificateEntityIntegrationTest.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/service/certificate/impl/KeyVaultCertificateEntityIntegrationTest.java
@@ -6,6 +6,7 @@ import com.github.nagyesta.lowkeyvault.model.v7_2.key.constants.KeyType;
 import com.github.nagyesta.lowkeyvault.model.v7_3.certificate.CertificatePolicyModel;
 import com.github.nagyesta.lowkeyvault.model.v7_3.certificate.SubjectAlternativeNames;
 import com.github.nagyesta.lowkeyvault.model.v7_3.certificate.X509CertificateModel;
+import com.github.nagyesta.lowkeyvault.service.key.ReadOnlyKeyVaultKeyEntity;
 import com.github.nagyesta.lowkeyvault.service.key.impl.EcKeyCreationInput;
 import com.github.nagyesta.lowkeyvault.service.secret.impl.SecretCreateInput;
 import com.github.nagyesta.lowkeyvault.service.vault.VaultFake;
@@ -22,8 +23,7 @@ import java.util.TreeSet;
 
 import static com.github.nagyesta.lowkeyvault.TestConstants.*;
 import static com.github.nagyesta.lowkeyvault.TestConstantsCertificateKeys.EMPTY_PASSWORD;
-import static com.github.nagyesta.lowkeyvault.TestConstantsCertificates.CERT_NAME_1;
-import static com.github.nagyesta.lowkeyvault.TestConstantsCertificates.CERT_NAME_2;
+import static com.github.nagyesta.lowkeyvault.TestConstantsCertificates.*;
 import static com.github.nagyesta.lowkeyvault.TestConstantsUri.HTTPS_LOCALHOST_8443;
 import static com.github.nagyesta.lowkeyvault.service.certificate.impl.CertAuthorityType.SELF_SIGNED;
 import static com.github.nagyesta.lowkeyvault.service.certificate.impl.CertAuthorityType.UNKNOWN;
@@ -79,6 +79,7 @@ class KeyVaultCertificateEntityIntegrationTest {
 
         //when
         final KeyVaultCertificateEntity actual = new KeyVaultCertificateEntity(CERT_NAME_1, input, vault);
+        final ReadOnlyKeyVaultKeyEntity actualKey = vault.keyVaultFake().getEntities().getReadOnlyEntity(actual.getKid());
 
         //then
         Assertions.assertEquals(certificate, actual.getCertificate());
@@ -97,6 +98,7 @@ class KeyVaultCertificateEntityIntegrationTest {
                 new TreeSet<>(originalPolicy.getKeyUsage()));
         Assertions.assertEquals(THIRTY_YEARS_IN_MONTHS, originalPolicy.getValidityMonths());
         Assertions.assertNotNull(actual.getOriginalCertificateContents());
+        Assertions.assertIterableEquals(ALL_KEY_OPERATIONS, actualKey.getOperations());
     }
 
     @Test

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/service/key/util/KeyGenUtilTest.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/service/key/util/KeyGenUtilTest.java
@@ -22,21 +22,21 @@ import java.security.spec.RSAKeyGenParameterSpec;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-class KeyGenUtilTest {
+import static com.github.nagyesta.lowkeyvault.TestConstantsKeys.MIN_AES_KEY_SIZE;
+import static com.github.nagyesta.lowkeyvault.TestConstantsKeys.MIN_RSA_KEY_SIZE;
 
-    private static final int AES_128 = 128;
-    private static final int RSA_2048 = 2048;
+class KeyGenUtilTest {
 
     public static Stream<Arguments> symmetricProvider() {
         return Stream.<Arguments>builder()
-                .add(Arguments.of(null, AES_128))
+                .add(Arguments.of(null, MIN_AES_KEY_SIZE))
                 .add(Arguments.of(KeyType.OCT_HSM.getAlgorithmName(), 1))
                 .build();
     }
 
     public static Stream<Arguments> asymmetricProvider() {
         return Stream.<Arguments>builder()
-                .add(Arguments.of(null, RSA_2048))
+                .add(Arguments.of(null, MIN_RSA_KEY_SIZE))
                 .add(Arguments.of(KeyType.RSA.getAlgorithmName(), 0))
                 .build();
     }
@@ -87,7 +87,7 @@ class KeyGenUtilTest {
         //given
 
         //when
-        final KeyPair actual = KeyGenUtil.generateRsa(RSA_2048, null);
+        final KeyPair actual = KeyGenUtil.generateRsa(MIN_RSA_KEY_SIZE, null);
 
         //then
         Assertions.assertNotNull(actual);
@@ -113,7 +113,7 @@ class KeyGenUtilTest {
         //given
 
         //when
-        final SecretKey actual = KeyGenUtil.generateAes(AES_128);
+        final SecretKey actual = KeyGenUtil.generateAes(MIN_AES_KEY_SIZE);
 
         //then
         Assertions.assertNotNull(actual);

--- a/lowkey-vault-docker/src/test/java/com/github/nagyesta/lowkeyvault/steps/CertificatesStepDefs.java
+++ b/lowkey-vault-docker/src/test/java/com/github/nagyesta/lowkeyvault/steps/CertificatesStepDefs.java
@@ -78,6 +78,7 @@ public class CertificatesStepDefs extends CommonAssertions {
             policy.setKeyType(CertificateKeyType.EC);
         }
         policy.setKeySize(null);
+        policy.setKeyUsage(CertificateKeyUsage.DIGITAL_SIGNATURE);
         context.setPolicy(policy);
     }
 
@@ -95,7 +96,7 @@ public class CertificatesStepDefs extends CommonAssertions {
     }
 
     @And("the certificate is created with name {name}")
-    public void rsaCertificateCreationRequestIsSentWithName(final String name) {
+    public void certificateCreationRequestIsSentWithName(final String name) {
         final CertificateClient client = context.getClient(context.getCertificateServiceVersion());
         client.beginCreateCertificate(name, context.getPolicy(), true, context.getTags())
                 .waitForCompletion();


### PR DESCRIPTION
__Issue:__ #1377 <!-- #issue number -->

### Description
<!-- A short summary of changes -->

- Generates key operations based on the certificate use
- Deduplicates test data for some certificate tests
- Certificate creation/import/restore operations set the appropriate key operations too
- Updates tests

### Entry point
<!-- Where should the reviewer start in order to properly understand the PR? -->

-

### Checklists

- [x] I have rebased my branch
- [x] My commit message is meaningful
- [x] The commit messages use semantic versioning: ```{major}```, ```{minor}``` or ```{patch}```
- [x] The changes are focusing on the issue at hand
- [x] I have maintained or increased test coverage

### Notes

> [!Warning]
> Might break earlier backups/exports if invalid certificate use values were selected (i.e. encryption/decryption with EC keys)
<!-- Any additional remarks you may have. -->
