### PR TITLE
feat: Possibility to persist data (keys, secrets, certs) automatically

### DIFF
--- a/.github/workflows/gradle-oss-index-scan.yml
+++ b/.github/workflows/gradle-oss-index-scan.yml
@@ -15,8 +15,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@f9c9c575b8b21b6485636a91ffecd10e558c62f6 # v3.5.0
       - name: Set up JDK 17
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 [![JavaCI](https://img.shields.io/github/actions/workflow/status/nagyesta/lowkey-vault/gradle.yml?logo=github&branch=main)](https://github.com/nagyesta/lowkey-vault/actions/workflows/gradle.yml)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/5577/badge)](https://bestpractices.coreinfrastructure.org/projects/5577)
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=nagyesta_lowkey-vault&metric=coverage)](https://sonarcloud.io/summary/new_code?id=nagyesta_lowkey-vault)
+[![Sonar Coverage](https://img.shields.io/sonar/coverage/nagyesta_lowkey-vault?server=https%3A%2F%2Fsonarcloud.io&logo=sonarcloud&logoColor=white)](https://sonarcloud.io/summary/new_code?id=nagyesta_lowkey-vault)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=nagyesta_lowkey-vault&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=nagyesta_lowkey-vault)
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=nagyesta_lowkey-vault&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=nagyesta_lowkey-vault)
 [![last_commit](https://img.shields.io/github/last-commit/nagyesta/lowkey-vault?logo=git)](https://img.shields.io/github/last-commit/nagyesta/lowkey-vault?logo=git)
@@ -82,6 +82,15 @@ See examples under [Lowkey Vault Testcontainers](lowkey-vault-testcontainers/REA
 ## Features
 
 Lowkey Vault is far from supporting all Azure Key Vault features. The list supported functionality can be found here:
+
+### General
+
+- Configure custom port to access Lowkey Vault
+- Use multiple aliases to access the same vault using different host names/ports
+- Automatically create default vaults on start-up
+- Simulate Managed Identity with fake token endpoint
+- Import previously exported contents during start-up
+- Automatically export contents after each change to a predefined file
 
 ### Keys
 
@@ -243,4 +252,5 @@ Used for metadata endpoints
 - Some encryption/signature algorithms are not supported. Please refer to the ["Features"](#features) section for the up-to-date list of supported algorithms.
 - Only self-signed certificates are supported by the certificate API.
 - Time shift cannot renew/recreate deleted certificates. Please consider performing deletions after time shift as a workaround.
-- Recovery options cannot be configured for vaults created during start-up
+- Recovery options cannot be configured for vaults created during start-up 
+- The Docker container uses the root user due to a limitation that prevented the custom user from writing the export file when the Docker UID on the host did not match the user's UID inside the container as a regular user.

--- a/lowkey-vault-app/README.md
+++ b/lowkey-vault-app/README.md
@@ -6,7 +6,7 @@
 [![Maven Central](https://img.shields.io/maven-central/v/com.github.nagyesta.lowkey-vault/lowkey-vault-app?logo=apache-maven)](https://search.maven.org/search?q=com.github.nagyesta.lowkey-vault)
 
 [![JavaCI](https://img.shields.io/github/actions/workflow/status/nagyesta/lowkey-vault/gradle.yml?logo=github&branch=main)](https://github.com/nagyesta/lowkey-vault/actions/workflows/gradle.yml)
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=nagyesta_lowkey-vault&metric=coverage)](https://sonarcloud.io/summary/new_code?id=nagyesta_lowkey-vault)
+[![Sonar Coverage](https://img.shields.io/sonar/coverage/nagyesta_lowkey-vault?server=https%3A%2F%2Fsonarcloud.io&logo=sonarcloud&logoColor=white)](https://sonarcloud.io/summary/new_code?id=nagyesta_lowkey-vault)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=nagyesta_lowkey-vault&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=nagyesta_lowkey-vault)
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=nagyesta_lowkey-vault&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=nagyesta_lowkey-vault)
 [![badge-abort-mission-armed-green](https://raw.githubusercontent.com/nagyesta/abort-mission/wiki_assets/.github/assets/badge-abort-mission-armed-green.svg)](https://github.com/nagyesta/abort-mission)
@@ -156,10 +156,37 @@ we can use `{{now <seconds>}}` placeholders (with positive or negative values as
 with the `<UTC_Epoch_seconds_now> + <seconds>` formula. This can allow you to use relative timestamps, in case
 your tests need a key of certain age relative to the time of the test execution.
 
+> [!TIP]
+> Since we want to import vault content, in order to avoid collisions, it is recommended to disable automatic vault registration when using the import feature by adding the `--LOWKEY_VAULT_NAMES=-` argument.
+
 Example:
 
 ```shell
 java -jar lowkey-vault-app-<version>.jar --LOWKEY_IMPORT_LOCATION=export.json --LOWKEY_IMPORT_TEMPLATE_HOST=127.0.0.1 --LOWKEY_IMPORT_TEMPLATE_PORT=443
+```
+
+### Exporting vault content on change
+
+There are some use-cases, where it is important to be able to export the content of the vault automatically after each change.
+In these cases, the export feature can be turned on by defining the file where the content should be written. 
+This feature is available using `v3.1.0` or higher.
+
+> [!NOTE]
+> The exports are not using any placeholders, it is recommended to always use the same host AND either always use the same port or turn on relaxed port matching.
+
+> [!WARNING]
+> This feature is not active by default because it can degrade the performance of Lowkey Vault significantly.
+
+> [!TIP]
+> Combining this feature with the import feature and using the same file as import source and export target can help you make Lowkey Vault persistent, allowing you to continue from where you have left off the last time.
+
+> [!CAUTION]
+> Despite the fact that the persistence can help you use the same vault contents every time when you run Lowkey Vault, please keep in mind, that you should never use Lowkey Vault to store real secrets/keys/certificates because it does absolutely nothing to keep them safe.
+
+Example:
+
+```shell
+java -jar lowkey-vault-app-<version>.jar --LOWKEY_EXPORT_LOCATION=export.json
 ```
 
 ### External configuration

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/filter/CommonAuthHeaderFilter.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/filter/CommonAuthHeaderFilter.java
@@ -7,6 +7,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpHeaders;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
@@ -20,9 +21,12 @@ import java.util.Optional;
 import java.util.Set;
 
 @Component
+@Order(CommonAuthHeaderFilter.PRECEDENCE)
 @Slf4j
 public class CommonAuthHeaderFilter
         extends OncePerRequestFilter {
+
+    static final int PRECEDENCE = 100;
 
     static final String OMIT_DEFAULT = "";
     private static final int DEFAULT_HTTPS_PORT = 443;

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/filter/ContentExportFilter.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/filter/ContentExportFilter.java
@@ -1,0 +1,126 @@
+package com.github.nagyesta.lowkeyvault.filter;
+
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.nagyesta.lowkeyvault.management.VaultImportExportExecutor;
+import com.github.nagyesta.lowkeyvault.model.common.ErrorMessage;
+import com.github.nagyesta.lowkeyvault.model.management.VaultBackupListModel;
+import com.github.nagyesta.lowkeyvault.service.vault.VaultService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Set;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static com.github.nagyesta.lowkeyvault.filter.ContentExportFilter.PRECEDENCE;
+
+@Component
+@Slf4j
+@Order(PRECEDENCE)
+public class ContentExportFilter
+        extends OncePerRequestFilter {
+
+    static final int PRECEDENCE = 200;
+
+    private static final Set<HttpMethod> METHODS_CHANGING_STATE = Set.of(
+            HttpMethod.DELETE, HttpMethod.PATCH, HttpMethod.POST, HttpMethod.PUT);
+
+    private final VaultImportExportExecutor vaultImportExportExecutor;
+    private final VaultService vaultService;
+    private final ObjectMapper objectMapper;
+    private final File exportFile;
+    private final ReentrantLock lock;
+
+    public ContentExportFilter(
+            @NonNull final VaultImportExportExecutor vaultImportExportExecutor,
+            @NonNull final VaultService vaultService,
+            @NonNull final ObjectMapper objectMapper,
+            @Value("${LOWKEY_EXPORT_LOCATION}") final File exportFile) {
+        this.vaultImportExportExecutor = vaultImportExportExecutor;
+        this.vaultService = vaultService;
+        this.objectMapper = objectMapper;
+        this.exportFile = exportFile;
+        lock = new ReentrantLock();
+    }
+
+    @SuppressWarnings("NullableProblems")
+    @Override
+    protected void doFilterInternal(
+            final HttpServletRequest request,
+            final HttpServletResponse response,
+            final FilterChain filterChain)
+            throws ServletException, IOException {
+        final var responseToUse = wrapResponseIfNecessary(request, response);
+        filterChain.doFilter(request, responseToUse);
+        finalizeResponse(responseToUse);
+    }
+
+    private HttpServletResponse wrapResponseIfNecessary(
+            final HttpServletRequest request,
+            final HttpServletResponse response) {
+        final HttpServletResponse responseToUse;
+        if (isEnabled() && canChangeState(request)) {
+            responseToUse = new ContentCachingResponseWrapper(response);
+        } else {
+            responseToUse = response;
+        }
+        return responseToUse;
+    }
+
+
+
+    private void finalizeResponse(final HttpServletResponse response) throws IOException {
+        if (response instanceof final ContentCachingResponseWrapper wrapper) {
+            if (wasSuccessful(response)) {
+                try {
+                    doExport();
+                } catch (final Exception e) {
+                    wrapper.reset();
+                    final var errorMessage = ErrorMessage.fromException(new IllegalStateException("Failed to export vault content.", e));
+                    objectMapper.writeValue(wrapper.getWriter(), errorMessage);
+                    wrapper.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+                }
+            }
+            wrapper.copyBodyToResponse();
+        }
+    }
+
+    private void doExport() throws IOException {
+        lock.lock();
+        try {
+            log.info("Exporting application state to file '{}'.", exportFile.getAbsolutePath());
+            final var backupModels = vaultImportExportExecutor.backupVaultList(vaultService);
+            final var vaultBackupListModel = new VaultBackupListModel();
+            vaultBackupListModel.setVaults(backupModels);
+            objectMapper.writer(new DefaultPrettyPrinter())
+                    .writeValue(exportFile, vaultBackupListModel);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private static boolean canChangeState(final HttpServletRequest request) {
+        return METHODS_CHANGING_STATE.contains(HttpMethod.valueOf(request.getMethod()));
+    }
+
+    private static boolean wasSuccessful(final HttpServletResponse response) {
+        return response.getStatus() < HttpServletResponse.SC_BAD_REQUEST;
+    }
+
+    private boolean isEnabled() {
+        return exportFile != null && !exportFile.getName().isBlank();
+    }
+
+}

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/filter/PortSeparationFilter.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/filter/PortSeparationFilter.java
@@ -5,15 +5,21 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
+import static com.github.nagyesta.lowkeyvault.filter.PortSeparationFilter.PRECEDENCE;
+
 @Component
 @Slf4j
+@Order(PRECEDENCE)
 public class PortSeparationFilter
         extends OncePerRequestFilter {
+
+    static final int PRECEDENCE = 50;
 
     @SuppressWarnings("NullableProblems")
     @Override

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/model/common/ErrorMessage.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/model/common/ErrorMessage.java
@@ -31,7 +31,7 @@ public class ErrorMessage {
     @JsonProperty("message")
     private String message;
 
-    static ErrorMessage fromException(final Throwable t) {
+    public static ErrorMessage fromException(final Throwable t) {
         return Optional.ofNullable(t)
                 .map(throwable -> new ErrorMessage(
                         throwable.getClass().getName(),

--- a/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/template/backup/VaultImporter.java
+++ b/lowkey-vault-app/src/main/java/com/github/nagyesta/lowkeyvault/template/backup/VaultImporter.java
@@ -44,9 +44,9 @@ public class VaultImporter
     @Autowired
     public VaultImporter(
             @NonNull final VaultImporterProperties vaultImporterProperties,
-                         @NonNull final BackupTemplateProcessor backupTemplateProcessor,
-                         @NonNull final ObjectMapper objectMapper,
-                         @NonNull final Validator validator) {
+            @NonNull final BackupTemplateProcessor backupTemplateProcessor,
+            @NonNull final ObjectMapper objectMapper,
+            @NonNull final Validator validator) {
         this.vaultImporterProperties = vaultImporterProperties;
         this.backupTemplateProcessor = backupTemplateProcessor;
         this.objectMapper = objectMapper;

--- a/lowkey-vault-app/src/main/resources/application.properties
+++ b/lowkey-vault-app/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 # suppress inspection "SpringBootApplicationProperties"
 application.version=@version@
 # suppress inspection "SpringBootApplicationProperties"
-application.formatted-version=\\ (v@version@)
+application.formatted-version=(v@version@)
 # suppress inspection "SpringBootApplicationProperties"
 application.title=Lowkey Vault
 #
@@ -34,3 +34,4 @@ logging.pattern.console=%clr(%d{HH:mm:ss.SSS}){faint} %clr(%5p){magenta} %clr([%
 logging.exception-conversion-word=%ex{5}
 
 LOWKEY_IMPORT_LOCATION=
+LOWKEY_EXPORT_LOCATION=

--- a/lowkey-vault-app/src/main/resources/banner.txt
+++ b/lowkey-vault-app/src/main/resources/banner.txt
@@ -18,5 +18,5 @@
 .                          [0;37m@@[0;34m/////[0;37m@@#[0;34m////[0;37m&@   @#[0;34m////[0;37m&@@[0;34m/////////[0;37m#@@@[0;34m//////////[0;37m@@&[0;34m////[0;37m@[0;0m                          .
 .                           [0;37m@@@@@@@@@@@@@@     @@@@@@@  @@@@@@@@   @@@@@@@@@@@@@@@@@@@[0;0m                          .
 .                                                                                                               .
-                           Lowkey Vault version: ${application.formatted-version}
+                           Lowkey Vault version:  ${application.formatted-version}
                                    Boot version: ${spring-boot.formatted-version}

--- a/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/filter/ContentExportFilterTest.java
+++ b/lowkey-vault-app/src/test/java/com/github/nagyesta/lowkeyvault/filter/ContentExportFilterTest.java
@@ -1,0 +1,213 @@
+package com.github.nagyesta.lowkeyvault.filter;
+
+import com.fasterxml.jackson.core.PrettyPrinter;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.github.nagyesta.lowkeyvault.management.VaultImportExportExecutor;
+import com.github.nagyesta.lowkeyvault.model.common.ErrorMessage;
+import com.github.nagyesta.lowkeyvault.model.management.VaultBackupListModel;
+import com.github.nagyesta.lowkeyvault.model.management.VaultBackupModel;
+import com.github.nagyesta.lowkeyvault.service.vault.VaultService;
+import jakarta.servlet.ServletException;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+import static org.springframework.http.HttpMethod.*;
+import static org.springframework.http.HttpStatus.*;
+
+class ContentExportFilterTest {
+
+    private static final File EXPORT_FILE = new File("export.json");
+    private static final String REQUEST_URI = "/path";
+    private static final String AN_EXPECTED_MESSAGE = "An expected message";
+
+    public static Stream<Arguments> emptyExportFileProvider() {
+        return Stream.<Arguments>builder()
+                .add(Arguments.of(new File("")))
+                .add(Arguments.of(new File(" ")))
+                .build();
+    }
+
+    public static Stream<Arguments> exportParameterProvider() {
+        final var builder = Stream.<Arguments>builder();
+        for (final var httpMethod : List.of(PUT, DELETE, PATCH, POST)) {
+            for (final var httpStatus : List.of(ACCEPTED, OK, NO_CONTENT, SEE_OTHER, NOT_MODIFIED)) {
+                builder.add(Arguments.of(httpMethod, httpStatus));
+            }
+        }
+        return builder.build();
+    }
+
+    public static Stream<Arguments> nullProvider() {
+        return Stream.<Arguments>builder()
+                .add(Arguments.of(null, null, null))
+                .add(Arguments.of(mock(VaultImportExportExecutor.class), null, null))
+                .add(Arguments.of(null, mock(VaultService.class), null))
+                .add(Arguments.of(null, null, mock(ObjectMapper.class)))
+                .add(Arguments.of(null, mock(VaultService.class), mock(ObjectMapper.class)))
+                .add(Arguments.of(mock(VaultImportExportExecutor.class), null, mock(ObjectMapper.class)))
+                .add(Arguments.of(mock(VaultImportExportExecutor.class), mock(VaultService.class), null))
+                .build();
+    }
+
+    @ParameterizedTest
+    @MethodSource("nullProvider")
+    void testConstructorShouldThrowExceptionWhenCalledWithNullDependencies(
+            final VaultImportExportExecutor executor,
+            final VaultService vaultService,
+            final ObjectMapper objectMapper) {
+        //given
+
+        //when
+        assertThrows(IllegalArgumentException.class, () -> new ContentExportFilter(executor, vaultService, objectMapper, EXPORT_FILE));
+
+        //then + exception
+    }
+
+    @ParameterizedTest
+    @MethodSource("emptyExportFileProvider")
+    @NullSource
+    void testDoFilterInternalShouldNotExportTheContentWhenTheExportFileIsNotSet(final File exportfile)
+            throws ServletException, IOException {
+        //given
+        final var executor = mock(VaultImportExportExecutor.class);
+        final var vaultService = mock(VaultService.class);
+        final var objectMapper = mock(ObjectMapper.class);
+        final var underTest = new ContentExportFilter(executor, vaultService, objectMapper, exportfile);
+        final var request = new MockHttpServletRequest(POST.name(), REQUEST_URI);
+        final var response = new MockHttpServletResponse();
+        final var filterChain = new MockFilterChain();
+
+        //when
+        underTest.doFilterInternal(request, response, filterChain);
+
+        //then
+        //no calls were made to perform the export
+        verifyNoMoreInteractions(executor, vaultService, objectMapper);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"get", "head", "option"})
+    void testDoFilterInternalShouldNotExportTheContentWhenTheRequestCannotChangeTheState(final String method)
+            throws ServletException, IOException {
+        //given
+        final var executor = mock(VaultImportExportExecutor.class);
+        final var vaultService = mock(VaultService.class);
+        final var objectMapper = mock(ObjectMapper.class);
+        final var underTest = new ContentExportFilter(executor, vaultService, objectMapper, EXPORT_FILE);
+        final var request = new MockHttpServletRequest(method, REQUEST_URI);
+        final var response = new MockHttpServletResponse();
+        final var filterChain = new MockFilterChain();
+
+        //when
+        underTest.doFilterInternal(request, response, filterChain);
+
+        //then
+        //no calls were made to perform the export
+        verifyNoMoreInteractions(executor, vaultService, objectMapper);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {400, 401, 404, 500, 503})
+    void testDoFilterInternalShouldNotExportTheContentWhenTheResponseIndicatesAnError(final int status)
+            throws ServletException, IOException {
+        //given
+        final var executor = mock(VaultImportExportExecutor.class);
+        final var vaultService = mock(VaultService.class);
+        final var objectMapper = mock(ObjectMapper.class);
+        final var underTest = new ContentExportFilter(executor, vaultService, objectMapper, EXPORT_FILE);
+        final var request = new MockHttpServletRequest(POST.name(), REQUEST_URI);
+        final var response = new MockHttpServletResponse();
+        response.setStatus(status);
+        final var filterChain = new MockFilterChain();
+
+        //when
+        underTest.doFilterInternal(request, response, filterChain);
+
+        //then
+        //no calls were made to perform the export
+        verifyNoMoreInteractions(executor, vaultService, objectMapper);
+    }
+
+    @ParameterizedTest
+    @MethodSource("exportParameterProvider")
+    void testDoFilterInternalShouldOverrideResponseContentWhenTheExportFails(
+            final HttpMethod method,
+            final HttpStatus status) throws ServletException, IOException {
+        //given
+        final var executor = mock(VaultImportExportExecutor.class);
+        final var vaultService = mock(VaultService.class);
+        final var list = List.of(new VaultBackupModel());
+        when(executor.backupVaultList(vaultService)).thenReturn(list);
+        final var objectMapper = mock(ObjectMapper.class);
+        final var objectWriter = mock(ObjectWriter.class);
+        when(objectMapper.writer(any(PrettyPrinter.class))).thenReturn(objectWriter);
+        doThrow(new IOException(AN_EXPECTED_MESSAGE)).when(objectWriter).writeValue(eq(EXPORT_FILE), any());
+        final var expectedBackup = new VaultBackupListModel();
+        expectedBackup.setVaults(list);
+        final var underTest = new ContentExportFilter(executor, vaultService, objectMapper, EXPORT_FILE);
+        final var request = new MockHttpServletRequest(method.name(), REQUEST_URI);
+        final var response = new MockHttpServletResponse();
+        response.setStatus(status.value());
+        final var filterChain = new MockFilterChain();
+
+        //when
+        underTest.doFilterInternal(request, response, filterChain);
+
+        //then
+        verify(executor).backupVaultList(same(vaultService));
+        verify(objectMapper).writer(any(PrettyPrinter.class));
+        verify(objectWriter).writeValue(EXPORT_FILE, expectedBackup);
+        verify(objectMapper).writeValue(any(PrintWriter.class), any(ErrorMessage.class));
+        verifyNoMoreInteractions(executor, vaultService, objectMapper);
+        assertEquals(INTERNAL_SERVER_ERROR.value(), response.getStatus());
+    }
+
+    @ParameterizedTest
+    @MethodSource("exportParameterProvider")
+    void testDoFilterInternalShouldExportTheContentWhenTheExportFileIsSetAndTheRequestCanChangeTheStateAndTheResponseIsSuccessful(
+            final HttpMethod method,
+            final HttpStatus status) throws ServletException, IOException {
+        //given
+        final var executor = mock(VaultImportExportExecutor.class);
+        final var vaultService = mock(VaultService.class);
+        final var list = List.of(new VaultBackupModel());
+        when(executor.backupVaultList(vaultService)).thenReturn(list);
+        final var objectMapper = mock(ObjectMapper.class);
+        final var objectWriter = mock(ObjectWriter.class);
+        when(objectMapper.writer(any(PrettyPrinter.class))).thenReturn(objectWriter);
+        final var expectedBackup = new VaultBackupListModel();
+        expectedBackup.setVaults(list);
+        final var underTest = new ContentExportFilter(executor, vaultService, objectMapper, EXPORT_FILE);
+        final var request = new MockHttpServletRequest(method.name(), REQUEST_URI);
+        final var response = new MockHttpServletResponse();
+        response.setStatus(status.value());
+        final var filterChain = new MockFilterChain();
+
+        //when
+        underTest.doFilterInternal(request, response, filterChain);
+
+        //then
+        verify(executor).backupVaultList(same(vaultService));
+        verify(objectMapper).writer(any(PrettyPrinter.class));
+        verify(objectWriter).writeValue(EXPORT_FILE, expectedBackup);
+        verifyNoMoreInteractions(executor, vaultService, objectMapper);
+    }
+}

--- a/lowkey-vault-client/README.md
+++ b/lowkey-vault-client/README.md
@@ -6,7 +6,7 @@
 [![Maven Central](https://img.shields.io/maven-central/v/com.github.nagyesta.lowkey-vault/lowkey-vault-app?logo=apache-maven)](https://search.maven.org/search?q=com.github.nagyesta.lowkey-vault)
 
 [![JavaCI](https://img.shields.io/github/actions/workflow/status/nagyesta/lowkey-vault/gradle.yml?logo=github&branch=main)](https://github.com/nagyesta/lowkey-vault/actions/workflows/gradle.yml)
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=nagyesta_lowkey-vault&metric=coverage)](https://sonarcloud.io/summary/new_code?id=nagyesta_lowkey-vault)
+[![Sonar Coverage](https://img.shields.io/sonar/coverage/nagyesta_lowkey-vault?server=https%3A%2F%2Fsonarcloud.io&logo=sonarcloud&logoColor=white)](https://sonarcloud.io/summary/new_code?id=nagyesta_lowkey-vault)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=nagyesta_lowkey-vault&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=nagyesta_lowkey-vault)
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=nagyesta_lowkey-vault&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=nagyesta_lowkey-vault)
 [![badge-abort-mission-armed-green](https://raw.githubusercontent.com/nagyesta/abort-mission/wiki_assets/.github/assets/badge-abort-mission-armed-green.svg)](https://github.com/nagyesta/abort-mission)

--- a/lowkey-vault-docker/README.md
+++ b/lowkey-vault-docker/README.md
@@ -7,7 +7,7 @@
 [![Docker Hub](https://img.shields.io/docker/v/nagyesta/lowkey-vault?sort=date&arch=arm64&logo=docker&label=multi-arch)](https://hub.docker.com/r/nagyesta/lowkey-vault)
 
 [![JavaCI](https://img.shields.io/github/actions/workflow/status/nagyesta/lowkey-vault/gradle.yml?logo=github&branch=main)](https://github.com/nagyesta/lowkey-vault/actions/workflows/gradle.yml)
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=nagyesta_lowkey-vault&metric=coverage)](https://sonarcloud.io/summary/new_code?id=nagyesta_lowkey-vault)
+[![Sonar Coverage](https://img.shields.io/sonar/coverage/nagyesta_lowkey-vault?server=https%3A%2F%2Fsonarcloud.io&logo=sonarcloud&logoColor=white)](https://sonarcloud.io/summary/new_code?id=nagyesta_lowkey-vault)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=nagyesta_lowkey-vault&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=nagyesta_lowkey-vault)
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=nagyesta_lowkey-vault&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=nagyesta_lowkey-vault)
 [![Docker Pulls](https://img.shields.io/docker/pulls/nagyesta/lowkey-vault?logo=docker)](https://hub.docker.com/r/nagyesta/lowkey-vault)
@@ -71,10 +71,69 @@ endpoint.
 docker run --rm --name lowkey -d -p 8080:8080 -p 8444:8444 nagyesta/lowkey-vault:<version>
 ```
 
+### Importing vault content at startup
+
+When you need to automatically import the contents of the vaults form a previously created JSON export, you can
+use a few parameters to customise the way import is happening. It is recommended to use the `/import` folder to mount
+a volume to be able to read the exported content from the host machine.
+
+| Property                      | Default         | Description                                                                                                  |
+| ----------------------------- | --------------- | ------------------------------------------------------------------------------------------------------------ |
+| `LOWKEY_IMPORT_LOCATION`      | `<null>`        | The JSON file we want to import. If left on default, or the file cannot be read, the import will not happen. |
+| `LOWKEY_IMPORT_TEMPLATE_HOST` | `localhost`     | The host name we want to use for replacing `{{host}}` placeholders in the JSON export (if there are any).    |
+| `LOWKEY_IMPORT_TEMPLATE_PORT` | `<server.port>` | The port number we want to use for replacing `{{port}}` placeholders in the JSON export (if there are any).  |
+
+Similarly to how `LOWKEY_IMPORT_TEMPLATE_HOST` and `LOWKEY_IMPORT_TEMPLATE_PORT` are replacing placeholders,
+we can use `{{now <seconds>}}` placeholders (with positive or negative values as well) which will be replaced
+with the `<UTC_Epoch_seconds_now> + <seconds>` formula. This can allow you to use relative timestamps, in case
+your tests need a key of certain age relative to the time of the test execution.
+
+> [!TIP]
+> Since we want to import vault content, in order to avoid collisions, it is recommended to disable automatic vault registration when using the import feature by adding the `--LOWKEY_VAULT_NAMES=-` argument.
+
+Example:
+
+```shell
+# Create volumes, allowing us to share the backup between the container and the host
+docker volume create -d local -o type=none -o o=bind -o device=$PWD/import docker-lv-import
+
+export LOWKEY_ARGS="--LOWKEY_VAULT_NAMES=- --LOWKEY_IMPORT_LOCATION=/import/export.json --LOWKEY_IMPORT_TEMPLATE_HOST=127.0.0.1 --LOWKEY_IMPORT_TEMPLATE_PORT=443"
+docker run --rm --name lowkey -e LOWKEY_ARGS -v docker-lv-import:/import/:rw -d -p 8443 nagyesta/lowkey-vault:<version>
+```
+
+### Exporting vault content on change
+
+There are some use-cases, where it is important to be able to export the content of the vault automatically after each change.
+In these cases, the export feature can be turned on by defining the file where the content should be written.
+This feature is available using `v3.1.0` or higher. It is recommended to use the `/import` folder to mount a volume with read 
+and write mode to be able to persist the exported content on the host machine.
+
+> [!NOTE]
+> The exports are not using any placeholders, it is recommended to always use the same host AND either always use the same port or turn on relaxed port matching.
+
+> [!WARNING]
+> This feature is not active by default because it can degrade the performance of Lowkey Vault significantly.
+
+> [!TIP]
+> Combining this feature with the import feature and using the same file as import source and export target can help you make Lowkey Vault persistent, allowing you to continue from where you have left off the last time.
+
+> [!CAUTION]
+> Despite the fact that the persistence can help you use the same vault contents every time when you run Lowkey Vault, please keep in mind, that you should never use Lowkey Vault to store real secrets/keys/certificates because it does absolutely nothing to keep them safe.
+
+Example:
+
+```shell
+# Create volumes, allowing us to share the backup between the container and the host
+docker volume create -d local -o type=none -o o=bind -o device=$PWD/import docker-lv-import
+
+export LOWKEY_ARGS="--LOWKEY_EXPORT_LOCATION=/import/export.json"
+docker run --rm --name lowkey -e LOWKEY_ARGS -v docker-lv-import:/import/:rw -d -p 8443 nagyesta/lowkey-vault:<version>
+```
+
 ### External configuration
 
 Since Lowkey Vault is a Spring Boot application, the default mechanism for Spring Boot external
-configuration can work as well. For example, if there is a ./config/application.properties file relative
+configuration can work as well. For example, if there is a `./config/application.properties` file relative
 to the folder where the Jar is running, the contents will be picked up automatically. To utilize this, the
-recommended option is to attach a \*.properties file to /config/application.properties (path inside the
+recommended option is to attach a `\*.properties` file to `/config/application.properties` (path inside the
 container) using a volume.

--- a/lowkey-vault-docker/src/docker/Dockerfile
+++ b/lowkey-vault-docker/src/docker/Dockerfile
@@ -3,16 +3,11 @@ LABEL maintainer="nagyesta@gmail.com"
 EXPOSE 8080 8443
 COPY lowkey-vault.jar /lowkey-vault.jar
 RUN \
-  addgroup -S lowkey && adduser -S lowkey -G lowkey && \
-  chown -R lowkey:lowkey "/lowkey-vault.jar" && \
   chmod 555 "/lowkey-vault.jar" && \
   mkdir "/import" && \
-  chown -R lowkey:lowkey "/import" && \
   chmod 755 "/import" && \
   mkdir "/config" && \
-  chown -R lowkey:lowkey "/config" && \
   chmod 555 "/config"
-USER lowkey
 WORKDIR /
 CMD [ "sh", "-c", "ls /" ]
 ENTRYPOINT ["sh", "-c", "java ${JAVA_OPTS} -jar /lowkey-vault.jar ${LOWKEY_ARGS}"]

--- a/lowkey-vault-testcontainers/README.md
+++ b/lowkey-vault-testcontainers/README.md
@@ -8,7 +8,7 @@
 [![Docker Hub](https://img.shields.io/docker/v/nagyesta/lowkey-vault?sort=date&arch=arm64&logo=docker&label=multi-arch)](https://hub.docker.com/r/nagyesta/lowkey-vault)
 
 [![JavaCI](https://img.shields.io/github/actions/workflow/status/nagyesta/lowkey-vault/gradle.yml?logo=github&branch=main)](https://github.com/nagyesta/lowkey-vault/actions/workflows/gradle.yml)
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=nagyesta_lowkey-vault&metric=coverage)](https://sonarcloud.io/summary/new_code?id=nagyesta_lowkey-vault)
+[![Sonar Coverage](https://img.shields.io/sonar/coverage/nagyesta_lowkey-vault?server=https%3A%2F%2Fsonarcloud.io&logo=sonarcloud&logoColor=white)](https://sonarcloud.io/summary/new_code?id=nagyesta_lowkey-vault)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=nagyesta_lowkey-vault&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=nagyesta_lowkey-vault)
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=nagyesta_lowkey-vault&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=nagyesta_lowkey-vault)
 [![badge-abort-mission-armed-green](https://raw.githubusercontent.com/nagyesta/abort-mission/wiki_assets/.github/assets/badge-abort-mission-armed-green.svg)](https://github.com/nagyesta/abort-mission)
@@ -118,12 +118,57 @@ class Test {
         return lowkeyVaultContainer;
     }
 }
-
 ```
 
 > [!NOTE]
 > Since `v2.7.0`, the container can use a dynamically allocated port thanks to the relaxed port matching feature. This will ignore the port number when searching for a vault based on the request authority (essentially only matching based
 > on the request's hostname).
+
+
+### Example using persistent vaults
+
+There are some use-cases, where it is important to be able to export the content of the vault automatically after each change.
+In these cases, the export feature can be turned on by defining the file where the content should be written.
+This feature is available using `v3.1.0` or higher. The module will help us mount the import/export file using read 
+and write mode to be able to persist the exported content on the host machine.
+
+> [!NOTE]
+> The exports are not using any placeholders, it is recommended to keep using the relaxed port matching feature which is turned-on by default using the `LowkeyVaultContainer`.
+
+> [!WARNING]
+> This feature is not active by default because it can degrade the performance of Lowkey Vault significantly.
+
+> [!TIP]
+> Turning on persistence using the `LowkeyVaultContainer` will use the same file as import and export locations, allowing you to continue from where you have left off the last time.
+
+> [!TIP]
+> When first starting your Lowkey Vault container with the persistence feature turned on, you will need either an initial import file or you need to make sure to create your vaults using the management API.
+
+> [!CAUTION]
+> Despite the fact that the persistence can help you use the same vault contents every time when you run Lowkey Vault, please keep in mind, that you should never use Lowkey Vault to store real secrets/keys/certificates because it does absolutely nothing to keep them safe.
+
+Example:
+
+```java
+import org.testcontainers.utility.DockerImageName;
+import com.github.nagyesta.lowkeyvault.testcontainers.LowkeyVaultContainer;
+import static com.github.nagyesta.lowkeyvault.testcontainers.LowkeyVaultContainerBuilder.lowkeyVault;
+
+class Test {
+    public LowkeyVaultContainer startVault(final File stateFile) {
+        //Please consider using latest image regardless of the value in the example
+        final DockerImageName imageName = DockerImageName.parse("nagyesta/lowkey-vault:<version>");
+        final LowkeyVaultContainer lowkeyVaultContainer = lowkeyVault(imageName)
+                .noAutoRegistration()
+                .persistent(stateFile)
+                .build()
+                .withImagePullPolicy(PullPolicy.defaultPolicy());
+        lowkeyVaultContainer.start();
+        return lowkeyVaultContainer;
+    }
+}
+
+```
 
 #### Example using your own certificate file
 

--- a/lowkey-vault-testcontainers/src/main/java/com/github/nagyesta/lowkeyvault/testcontainers/LowkeyVaultArgLineBuilder.java
+++ b/lowkey-vault-testcontainers/src/main/java/com/github/nagyesta/lowkeyvault/testcontainers/LowkeyVaultArgLineBuilder.java
@@ -5,6 +5,8 @@ import java.util.*;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import static com.github.nagyesta.lowkeyvault.testcontainers.LowkeyVaultContainer.IMPORT_FILE_CONTAINER_PATH;
+
 public class LowkeyVaultArgLineBuilder {
     private static final String NO_AUTO_REGISTRATION_VALUE = "-";
     private static final Set<String> NO_AUTO_REGISTRATION = Set.of(NO_AUTO_REGISTRATION_VALUE);
@@ -49,9 +51,29 @@ public class LowkeyVaultArgLineBuilder {
         return this;
     }
 
+    public LowkeyVaultArgLineBuilder usePersistence(final String containerPath) {
+        importFile(containerPath);
+        exportFile(containerPath);
+        return this;
+    }
+
+    /**
+     * Defines the import file from the host file system.
+     * @param file the import file on the host
+     * @return builder
+     * @deprecated Marked for removal, please use {@link #importFile(String)}.
+     */
+    @Deprecated(forRemoval = true)
     public LowkeyVaultArgLineBuilder importFile(final File file) {
         if (file != null) {
-            args.add("--LOWKEY_IMPORT_LOCATION=/import/vaults.json");
+            return importFile(IMPORT_FILE_CONTAINER_PATH);
+        }
+        return this;
+    }
+
+    public LowkeyVaultArgLineBuilder importFile(final String containerPath) {
+        if (containerPath != null) {
+            args.add("--LOWKEY_IMPORT_LOCATION=" + containerPath);
         }
         return this;
     }
@@ -85,6 +107,12 @@ public class LowkeyVaultArgLineBuilder {
 
     public List<String> build() {
         return Collections.unmodifiableList(args);
+    }
+
+    private void exportFile(final String containerPath) {
+        if (containerPath != null) {
+            args.add("--LOWKEY_EXPORT_LOCATION=" + containerPath);
+        }
     }
 
     private void assertVaultNamesAreValid(final Set<String> vaultNames) {

--- a/lowkey-vault-testcontainers/src/test/java/com/github/nagyesta/lowkeyvault/testcontainers/LowkeyVaultArgLineBuilderTest.java
+++ b/lowkey-vault-testcontainers/src/test/java/com/github/nagyesta/lowkeyvault/testcontainers/LowkeyVaultArgLineBuilderTest.java
@@ -134,6 +134,7 @@ class LowkeyVaultArgLineBuilderTest {
     }
 
     @Test
+    @SuppressWarnings({"deprecation", "removal"})
     void testImportFileShouldSetArgumentWhenCalledWithFile() {
         //given
         final var underTest = new LowkeyVaultArgLineBuilder();
@@ -149,13 +150,57 @@ class LowkeyVaultArgLineBuilderTest {
     }
 
     @Test
-    void testImportFileShouldNotSetArgumentWhenCalledWithNull() {
+    void testImportFileShouldSetArgumentWhenCalledWithString() {
+        //given
+        final var underTest = new LowkeyVaultArgLineBuilder();
+        final var expected = List.of(
+                "--LOWKEY_VAULT_RELAXED_PORTS=true",
+                "--LOWKEY_IMPORT_LOCATION=/import/import.json");
+
+        //when
+        final var actual = underTest.importFile("/import/import.json").build();
+
+        //then
+        Assertions.assertIterableEquals(expected, actual);
+    }
+
+    @Test
+    void testImportFileShouldNotSetArgumentWhenCalledWithNullString() {
         //given
         final var underTest = new LowkeyVaultArgLineBuilder();
         final var expected = List.of("--LOWKEY_VAULT_RELAXED_PORTS=true");
 
         //when
-        final var actual = underTest.importFile(null).build();
+        final var actual = underTest.importFile((String) null).build();
+
+        //then
+        Assertions.assertIterableEquals(expected, actual);
+    }
+
+    @Test
+    void testUsePersistenceShouldSetArgumentWhenCalledWithString() {
+        //given
+        final var underTest = new LowkeyVaultArgLineBuilder();
+        final var expected = List.of(
+                "--LOWKEY_VAULT_RELAXED_PORTS=true",
+                "--LOWKEY_IMPORT_LOCATION=/import/vaults.json",
+                "--LOWKEY_EXPORT_LOCATION=/import/vaults.json");
+
+        //when
+        final var actual = underTest.usePersistence("/import/vaults.json").build();
+
+        //then
+        Assertions.assertIterableEquals(expected, actual);
+    }
+
+    @Test
+    void testUsePersistenceShouldNotSetArgumentWhenCalledWithNullString() {
+        //given
+        final var underTest = new LowkeyVaultArgLineBuilder();
+        final var expected = List.of("--LOWKEY_VAULT_RELAXED_PORTS=true");
+
+        //when
+        final var actual = underTest.usePersistence(null).build();
 
         //then
         Assertions.assertIterableEquals(expected, actual);

--- a/lowkey-vault-testcontainers/src/test/java/com/github/nagyesta/lowkeyvault/testcontainers/LowkeyVaultContainerTest.java
+++ b/lowkey-vault-testcontainers/src/test/java/com/github/nagyesta/lowkeyvault/testcontainers/LowkeyVaultContainerTest.java
@@ -1,12 +1,16 @@
 package com.github.nagyesta.lowkeyvault.testcontainers;
 
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
+import org.testcontainers.containers.BindMode;
 import org.testcontainers.shaded.org.apache.commons.lang3.StringUtils;
 import org.testcontainers.utility.DockerImageName;
 
+import java.io.File;
 import java.util.stream.Stream;
 
 import static org.mockito.Mockito.*;
@@ -14,12 +18,13 @@ import static org.mockito.Mockito.*;
 class LowkeyVaultContainerTest extends AbstractLowkeyVaultContainerTest {
 
     public static Stream<Arguments> imageRecommendationInputProvider() {
+        final var imageName = getCurrentLowkeyVaultImageName();
         return Stream.<Arguments>builder()
-                .add(Arguments.of("nagyesta/lowkey-vault:2.7.1", "amd64", false))
-                .add(Arguments.of("nagyesta/lowkey-vault:2.7.1", "arm64", true))
-                .add(Arguments.of("nagyesta/lowkey-vault:2.7.1-ubi9-minimal", "amd64", false))
-                .add(Arguments.of("lowkey-vault:2.7.1", "amd64", false))
-                .add(Arguments.of("lowkey-vault:2.7.1", "arm64", false))
+                .add(Arguments.of("nagyesta/" + imageName, "amd64", false))
+                .add(Arguments.of("nagyesta/" + imageName, "arm64", true))
+                .add(Arguments.of("nagyesta/" + imageName + "-ubi9-minimal", "amd64", false))
+                .add(Arguments.of(imageName, "amd64", false))
+                .add(Arguments.of(imageName, "arm64", false))
                 .build();
     }
 
@@ -51,5 +56,32 @@ class LowkeyVaultContainerTest extends AbstractLowkeyVaultContainerTest {
                     "See more information: https://github.com/nagyesta/lowkey-vault/tree/main/lowkey-vault-docker#arm-builds");
         }
         verifyNoMoreInteractions(loggerMock);
+    }
+
+    @Test
+    void testContainerBuilderShouldThrowExceptionWhenPersistenceIsSetButImportFileIsMissing() {
+        //given
+        final var underTest = LowkeyVaultContainerBuilder
+                .lowkeyVault(getCurrentLowkeyVaultImageName())
+                .persistent();
+
+        //when
+        Assertions.assertThrows(IllegalArgumentException.class, underTest::build);
+
+        //then + exception
+    }
+
+    @Test
+    void testContainerBuilderShouldThrowExceptionWhenPersistenceIsSetButImportFileBindModeIsReadOnly() {
+        //given
+        final var underTest = LowkeyVaultContainerBuilder
+                .lowkeyVault(getCurrentLowkeyVaultImageName())
+                .importFile(new File("import"), BindMode.READ_ONLY)
+                .persistent();
+
+        //when
+        Assertions.assertThrows(IllegalArgumentException.class, underTest::build);
+
+        //then + exception
     }
 }

--- a/lowkey-vault-testcontainers/src/test/resources/empty-import.json
+++ b/lowkey-vault-testcontainers/src/test/resources/empty-import.json
@@ -1,0 +1,15 @@
+{
+  "vaults": [
+    {
+      "attributes": {
+        "baseUri": "https://localhost:8443",
+        "recoveryLevel": "Recoverable+Purgeable",
+        "recoverableDays": 90,
+        "created": 1647809444,
+        "deleted": null
+      },
+      "keys": {},
+      "secrets": {}
+    }
+  ]
+}


### PR DESCRIPTION
**Issue:** #1411

### Description

<!-- A short summary of changes -->

- Fix banner and version
- Set filter order
- Add new filter to automatically export the application state when necessary
- Describe the new feature in the documentation for Java and Docker
- Add support for the new feature in the Lowkey Vault Testcontainers module
- Provide example in the Testcontainers module documentation
- Update Dockerfile to start using root user again
- Remove outdated Gradle wrapper verification from OSS index scan workflow
- Update readme
- Cover new functionality with tests

### Entry point

<!-- Where should the reviewer start in order to properly understand the PR? -->

-

### Checklists

- [x] I have rebased my branch
- [x] My commit message is meaningful
- [x] The commit messages use semantic versioning: `{major}`, `{minor}` or `{patch}`
- [x] The changes are focusing on the issue at hand
- [x] I have maintained or increased test coverage

### Notes

> [!WARNING]
> Started using the root user in the Docker container because of a Docker limitation.
